### PR TITLE
fix: use Object.defineProperty for navigator polyfill

### DIFF
--- a/cli/scripts/inject.js
+++ b/cli/scripts/inject.js
@@ -1,7 +1,11 @@
-global.navigator = {
-    ...(global.navigator || {}),
-    platform: 'system',
-};
+Object.defineProperty(globalThis, 'navigator', {
+    value: {
+        ...(globalThis.navigator || {}),
+        platform: 'system',
+    },
+    writable: true,
+    configurable: true,
+});
 
 global.RTCPeerConnection = require('@roamhq/wrtc').RTCPeerConnection;
 global.RTCSessionDescription = require('@roamhq/wrtc').RTCSessionDescription;


### PR DESCRIPTION
## Summary

Fixes the global navigator polyfill in the CLI inject script to use `Object.defineProperty` on `globalThis` instead of direct assignment. This resolves issues in environments where `navigator` is a read-only property.

Resolves #93

## Changes

- Replace direct `global.navigator` assignment with `Object.defineProperty` on `globalThis` (`d316f28`)
- Set `writable` and `configurable` to `true` for compatibility
- Use `globalThis` instead of `global` for the navigator reference

## Testing Checklist

- [ ] Verify CLI peer connection initialization works correctly
- [x] Test in environments where `navigator` was previously read-only