### PR TITLE
fix: use publishConfig to resolve changeset publish name collision

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,10 @@
   ],
   "license": "MIT",
   "private": false,
+  "publishConfig": {
+    "name": "deadrop",
+    "access": "public"
+  },
   "scripts": {
     "test": "vitest run",
     "prebuild": "sh ./scripts/prebuild.sh",
@@ -20,8 +24,7 @@
     "compile": "bun run ./scripts/bun-build.ts",
     "postcompile": "rimraf fonts/",
     "postversion": "sh ./scripts/postversion.sh",
-    "prepublishOnly": "sh ./scripts/prepublish.sh",
-    "postpublish": "sh ./scripts/postpublish.sh",
+    "prepublishOnly": "pnpm build",
     "release": "pnpm build && npm publish"
   },
   "dependencies": {

--- a/cli/scripts/postpublish.sh
+++ b/cli/scripts/postpublish.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-npx replace '"name": "deadrop"' '"name": "cli"' ./package.json

--- a/cli/scripts/prepublish.sh
+++ b/cli/scripts/prepublish.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-npx replace '"name": "cli"' '"name": "deadrop"' ./package.json


### PR DESCRIPTION
## Summary

Fixes the release pipeline — `changeset publish` was skipping `cli` because it checked npm for the workspace name (`cli`) and found a collision with an unrelated package at `0.3.0`. `deadrop@0.3.0` was never published and no tag was created.

## Changes

- `cli/package.json` — add `publishConfig: { name: "deadrop", access: "public" }`; changesets now checks `deadrop@0.3.0` on npm (correct), proceeds with publish
- `cli/package.json` — `prepublishOnly` simplified to `pnpm build`; name flip no longer needed
- Delete `cli/scripts/prepublish.sh` and `cli/scripts/postpublish.sh` — replaced by `publishConfig.name`

## Testing Checklist

- [ ] Merge this PR → `release.yml` triggers, no pending changesets → runs `changeset publish`
- [ ] `deadrop@0.3.0` published to npm, `cli@0.3.0` tag pushed
- [ ] `cli@0.3.0` tag triggers binary matrix + GitHub Release