### PR TITLE
fix: v1.0.1 CLI hotfix — TURN creds not baked, wrong grab-link domain

### DIFF
--- a/.changeset/cli-hotfix-turn-and-grab-url.md
+++ b/.changeset/cli-hotfix-turn-and-grab-url.md
@@ -1,0 +1,16 @@
+---
+"cli": patch
+---
+
+Fix broken `drop`/`grab` in the published v1.0.0 CLI.
+
+TURN credentials were never baked into either compiled distribution
+(the npm package's esbuild bundle, and the standalone Bun release
+binaries), so every real install crashed on first peer connection with
+`InvalidAccessError: IceServers username cannot be null`. Both build
+scripts now require and bake `TURN_USERNAME`/`TURN_PWD` alongside the
+other platform constants.
+
+Also fixes the printed grab link pointing at the Worker API domain
+instead of the web app — `deadrop drop`'s grab link/QR code now
+resolves to a page a recipient can actually open.

--- a/.github/workflows/cli_e2e_workflow.yml
+++ b/.github/workflows/cli_e2e_workflow.yml
@@ -40,6 +40,8 @@ jobs:
           # bundle (and guards on both), so they must be present for `pnpm build`.
           DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
           PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
+          DEADROP_APP_URL: ${{ vars.DEADROP_APP_URL }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           # Runtime: initPeer reads the TURN creds from the env at run time.
           TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
           TURN_PWD: ${{ secrets.TURN_PWD }}

--- a/.github/workflows/e2e_ci_workflow.yml
+++ b/.github/workflows/e2e_ci_workflow.yml
@@ -54,16 +54,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build CLI binary (Bun)
-        # bun-build.ts bakes these via `define` and asserts all four are set.
+        # bun-build.ts bakes all six via `define` and asserts all six are set.
         # URLs + the Clerk publishable key are non-secret, so they live as
         # repo-level vars (the env-scoped NEXT_PUBLIC_* copies aren't readable
-        # here — this job deliberately has no `environment:`). TURN is a runtime
-        # var (set on the test step), not baked.
+        # here — this job deliberately has no `environment:`).
         env:
           DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
           PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
           DEADROP_APP_URL: ${{ vars.DEADROP_APP_URL }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
+          TURN_PWD: ${{ secrets.TURN_PWD }}
         run: pnpm -F cli compile
 
       - name: Install Playwright browsers

--- a/cli/lib/util.ts
+++ b/cli/lib/util.ts
@@ -3,7 +3,7 @@ import { engines } from '../../package.json';
 import { generateGrabUrl as baseGenerateGrabUrl } from '@shared/lib/util';
 
 export const generateGrabUrl = (id: string) =>
-  baseGenerateGrabUrl(process.env.DEADROP_API_URL!, id);
+  baseGenerateGrabUrl(process.env.DEADROP_APP_URL!, id);
 
 export const checkNodeVersion = () => {
   // Under a Bun-compiled binary - Node.js is not needed

--- a/cli/scripts/bun-build.ts
+++ b/cli/scripts/bun-build.ts
@@ -34,6 +34,8 @@ const env = {
   DEADROP_APP_URL: process.env.DEADROP_APP_URL!,
   PEER_SERVER_URL: process.env.PEER_SERVER_URL!,
   CLERK_PUBLISHABLE_KEY: process.env.CLERK_PUBLISHABLE_KEY!,
+  TURN_USERNAME: process.env.TURN_USERNAME!,
+  TURN_PWD: process.env.TURN_PWD!,
 };
 
 const missing = Object.entries(env)
@@ -47,10 +49,9 @@ if (missing.length) {
 }
 
 const envVars = Object.fromEntries(
-  Object.entries(env).map(([k, v]) => [
-    `process.env.${k}`,
-    JSON.stringify(v),
-  ]),
+  Object.entries(env)
+    .filter(([, v]) => v)
+    .map(([k, v]) => [`process.env.${k}`, JSON.stringify(v)]),
 );
 
 // Inject figlet font data as a build-time constant

--- a/cli/scripts/esbuild.js
+++ b/cli/scripts/esbuild.js
@@ -3,8 +3,20 @@ require('dotenv').config();
 const { build } = require('esbuild');
 const { environmentPlugin } = require('esbuild-plugin-environment');
 
-if (!process.env.DEADROP_API_URL || !process.env.PEER_SERVER_URL) {
-  console.error('Invalid environment configuration provided');
+const requiredEnv = [
+  'DEADROP_API_URL',
+  'DEADROP_APP_URL',
+  'PEER_SERVER_URL',
+  'CLERK_PUBLISHABLE_KEY',
+  'TURN_USERNAME',
+  'TURN_PWD',
+];
+
+const missing = requiredEnv.filter((key) => !process.env[key]);
+if (missing.length) {
+  console.error(
+    `Invalid environment configuration, missing: ${missing.join(', ')}`,
+  );
   process.exit(1);
 }
 
@@ -23,6 +35,8 @@ if (!process.env.DEADROP_API_URL || !process.env.PEER_SERVER_URL) {
         DEADROP_APP_URL: process.env.DEADROP_APP_URL,
         PEER_SERVER_URL: process.env.PEER_SERVER_URL,
         CLERK_PUBLISHABLE_KEY: process.env.CLERK_PUBLISHABLE_KEY,
+        TURN_USERNAME: process.env.TURN_USERNAME,
+        TURN_PWD: process.env.TURN_PWD,
       }),
     ],
 


### PR DESCRIPTION
## Summary

First hotfix following v1.0.0 — `drop`/`grab` was completely broken in the published CLI (both the npm package and the GitHub Release binaries), and the printed grab link pointed at the wrong domain.

- **TURN credentials never baked into either compiled distribution.** Neither `cli/scripts/bun-build.ts` (standalone release binaries) nor `cli/scripts/esbuild.js` (npm-published `dist/deadrop.js`) included `TURN_USERNAME`/`TURN_PWD` in their build-time env bake. Real installs crashed on first peer connection with `InvalidAccessError: IceServers username cannot be null`, since those env vars are never set in an end user's shell. Both scripts now require and bake all six platform constants uniformly, failing loudly at build time if any are missing (verified with `.env` removed from a clean checkout).
- **`e2e_ci_workflow.yml`** updated to pass `TURN_USERNAME`/`TURN_PWD` at its "Build CLI binary" step too, matching the same required set — it already had access to those secrets for the later test-invocation step.
- **Grab link pointed at the Worker API domain instead of the web app** (`cli/lib/util.ts`) — `generateGrabUrl` was reading `DEADROP_API_URL` instead of `DEADROP_APP_URL`, so the printed link/QR code resolved to the API host, not a page a recipient could open.
- Changeset added: `cli: patch`.

## Test plan

- [x] `pnpm test` — 127/127 passing
- [x] Compiled via `bun-build.ts` with TURN creds present — confirmed baked into the binary (`strings` check) and full `drop`/`grab` round-trip succeeded with an empty (`env -i`) process environment
- [x] Compiled via `bun-build.ts` with TURN creds absent (real CI checkout scenario, `.env` removed) — fails loudly with `Invalid environment configuration, missing: TURN_USERNAME, TURN_PWD` instead of silently shipping a broken binary
- [x] Same two checks repeated for `esbuild.js` / `dist/deadrop.js` — bakes correctly when present, fails loudly when absent, full round-trip succeeded
- [ ] CI green on this PR
- [ ] Manual smoke test against the actual published `deadrop@1.0.1` once cut