### PR TITLE
feat (cli): add deadrop update command + install.sh progress bar

### DIFF
--- a/.changeset/cli-update-command.md
+++ b/.changeset/cli-update-command.md
@@ -1,0 +1,11 @@
+---
+'cli': minor
+---
+
+Added a `deadrop update` command — run it and the CLI checks for a
+newer release, downloads and verifies it, and reports the version
+change. Works whether you installed via `npm`/`pnpm`/`yarn`/`bun` or
+the standalone binary from `install.sh`.
+
+`install.sh` also now shows a progress bar while downloading the
+binary instead of running silently.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -24,6 +24,7 @@ cli/
 │   ├── init.ts           # init: CLI setup wizard
 │   ├── login.ts          # login: Clerk auth
 │   ├── logout.ts
+│   ├── update.ts         # update: self-update (npm or binary path via lib/update/)
 │   ├── vault/            # vault subcommands
 │   │   ├── create.ts
 │   │   ├── use.ts
@@ -54,6 +55,12 @@ cli/
 │   │   ├── index.ts       # Logger setup
 │   │   ├── text.ts        # chalk text formatting
 │   │   └── loader.ts      # Ora spinners
+│   ├── update/
+│   │   ├── version.ts     # GitHub release / npm registry latest-version lookups
+│   │   ├── binary.ts      # Binary-install self-update (download, checksum, atomic replace)
+│   │   ├── npm.ts         # npm-install update (package manager detection + global install)
+│   │   ├── download.ts    # Streamed download + progress bar rendering
+│   │   └── checksum.ts    # SHA-256 verification helpers
 │   ├── constants.ts
 │   └── util.ts            # Node.js utilities
 ├── db/
@@ -82,6 +89,7 @@ cli/
 deadrop init            # First-time setup
 deadrop login           # Authenticate with Clerk
 deadrop logout
+deadrop update           # Update to the latest version (npm or standalone binary)
 deadrop drop            # Share a secret (drives dropMachine)
 deadrop grab            # Receive a secret (drives grabMachine)
 deadrop vault create    # Create a local vault

--- a/cli/actions/update.ts
+++ b/cli/actions/update.ts
@@ -1,0 +1,16 @@
+import { version } from '../package.json';
+import { logError } from 'lib/log';
+import { updateBinaryInstall, updateNpmInstall } from 'lib/update';
+
+export default async function update() {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary')
+      await updateBinaryInstall(version);
+    else await updateNpmInstall(version);
+
+    process.exit(0);
+  } catch (err) {
+    logError(`Update failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -15,6 +15,7 @@ import {
   vaultUse,
 } from 'actions/vault';
 import logout from 'actions/logout';
+import update from 'actions/update';
 import { displayWelcomeMessage } from 'lib/log';
 
 const deadrop = new Command();
@@ -33,6 +34,11 @@ deadrop.command('init').action(init);
 deadrop.command('login').action(login);
 
 deadrop.command('logout').action(logout);
+
+deadrop
+  .command('update')
+  .description('update deadrop to the latest version')
+  .action(update);
 
 deadrop
   .command('drop')

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -32,7 +32,7 @@ echo "Downloading deadrop ${TAG} (${OS}/${ARCH})..."
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-curl -fsSL "$URL" -o "$TMP/$BINARY"
+curl -fsSL --progress-bar "$URL" -o "$TMP/$BINARY"
 curl -fsSL "${URL}.sha256" -o "$TMP/$BINARY.sha256" || {
   echo "Could not download checksum for verification" >&2
   exit 1

--- a/cli/lib/constants.ts
+++ b/cli/lib/constants.ts
@@ -7,3 +7,37 @@ export const LOGIN_URL = `${DEADROP_URL}/auth/cli`;
 export const LOCALHOST_AUTH_PORT = 1337;
 
 export const LOCALHOST_AUTH_URL = `http://localhost:${LOCALHOST_AUTH_PORT}`;
+
+// `deadrop update` binary-install path — same repo/naming convention as install.sh
+export const GITHUB_REPO = 'dallen4/deadrop';
+export const BINARY_NAME = 'deadrop';
+export const GITHUB_LATEST_RELEASE_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+export const NPM_REGISTRY_LATEST_URL =
+  'https://registry.npmjs.org/deadrop/latest';
+
+// mirrors install.sh's `uname -s`/`uname -m` case statements
+const RELEASE_PLATFORM_MAP: Partial<Record<NodeJS.Platform, string>> = {
+  darwin: 'darwin',
+  linux: 'linux',
+};
+
+const RELEASE_ARCH_MAP: Record<string, string> = {
+  arm64: 'arm64',
+  x64: 'x64',
+};
+
+export const resolveReleaseAssetName = (
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): string => {
+  const os = RELEASE_PLATFORM_MAP[platform];
+  const mappedArch = RELEASE_ARCH_MAP[arch];
+
+  if (!os || !mappedArch)
+    throw new Error(`Unsupported platform: ${platform}/${arch}`);
+
+  return `${BINARY_NAME}-${os}-${mappedArch}`;
+};
+
+export const releaseAssetUrl = (tag: string, assetName: string) =>
+  `https://github.com/${GITHUB_REPO}/releases/download/${tag}/${assetName}`;

--- a/cli/lib/update/binary.ts
+++ b/cli/lib/update/binary.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'crypto';
+import { chmodSync, renameSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  GITHUB_REPO,
+  releaseAssetUrl,
+  resolveReleaseAssetName,
+} from 'lib/constants';
+import { logInfo } from 'lib/log';
+import { fetchExpectedChecksum, verifyChecksum } from './checksum';
+import { downloadBinaryWithProgress } from './download';
+import { fetchLatestBinaryVersion, isNewerVersion } from './version';
+
+export const RELEASES_PAGE_URL = `https://github.com/${GITHUB_REPO}/releases`;
+
+// Atomic replace: the currently-running process keeps executing off the
+// unlinked old inode, so this is safe to call while `deadrop` is running.
+export const replaceRunningBinary = (
+  tmpPath: string,
+  targetPath: string = process.execPath,
+): void => {
+  chmodSync(tmpPath, 0o755);
+  renameSync(tmpPath, targetPath);
+};
+
+export async function updateBinaryInstall(
+  currentVersion: string,
+): Promise<void> {
+  const latest = await fetchLatestBinaryVersion();
+
+  if (!isNewerVersion(latest, currentVersion)) {
+    logInfo(`Already on the latest version (v${currentVersion})`);
+    return;
+  }
+
+  // install.sh (and the release matrix it downloads from) never supported
+  // Windows — a win32 binary user got here by hand-downloading the .exe,
+  // so an in-place self-replace isn't attempted; point back to Releases.
+  if (process.platform === 'win32') {
+    logInfo(
+      `A newer version (v${latest}) is available, but automatic ` +
+        `updates aren't supported on Windows yet. Download it manually:\n` +
+        RELEASES_PAGE_URL,
+    );
+    return;
+  }
+
+  const tag = `deadrop@${latest}`;
+  const assetName = resolveReleaseAssetName();
+  const assetUrl = releaseAssetUrl(tag, assetName);
+  const tmpPath = join(tmpdir(), `${assetName}-${randomUUID()}`);
+
+  logInfo(`Downloading deadrop v${latest}...`);
+
+  await downloadBinaryWithProgress(assetUrl, tmpPath);
+
+  const expectedChecksum = await fetchExpectedChecksum(`${assetUrl}.sha256`);
+  const valid = await verifyChecksum(tmpPath, expectedChecksum);
+
+  if (!valid) {
+    unlinkSync(tmpPath);
+    throw new Error('Checksum verification failed — update aborted.');
+  }
+
+  replaceRunningBinary(tmpPath);
+
+  logInfo(`v${currentVersion} → v${latest}`);
+}

--- a/cli/lib/update/checksum.ts
+++ b/cli/lib/update/checksum.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'crypto';
+import { createReadStream } from 'fs';
+
+export const computeSha256 = (filePath: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+    stream.on('error', reject);
+  });
+
+// install.sh generates checksum files via `sha256sum $f > $f.sha256`,
+// i.e. `<hex>  <filename>` — only the first token matters
+export const parseChecksumFile = (content: string): string =>
+  content.trim().split(/\s+/)[0];
+
+export const fetchExpectedChecksum = async (
+  checksumUrl: string,
+): Promise<string> => {
+  const res = await fetch(checksumUrl);
+
+  if (!res.ok)
+    throw new Error(
+      `Failed to fetch checksum (${res.status} ${res.statusText})`,
+    );
+
+  return parseChecksumFile(await res.text());
+};
+
+export const verifyChecksum = async (
+  filePath: string,
+  expectedHex: string,
+): Promise<boolean> => {
+  const actual = await computeSha256(filePath);
+
+  return actual.toLowerCase() === expectedHex.toLowerCase();
+};

--- a/cli/lib/update/download.ts
+++ b/cli/lib/update/download.ts
@@ -1,0 +1,68 @@
+import { createWriteStream } from 'fs';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import type { ReadableStream as WebReadableStream } from 'stream/web';
+
+export type ProgressListener = (
+  received: number,
+  total: number,
+) => void;
+
+// pure formatting — kept separate from the stream plumbing so it's easy
+// to unit test without touching the network or filesystem
+export const formatProgressBar = (
+  received: number,
+  total: number,
+  width = 30,
+): string => {
+  const toMb = (bytes: number) => (bytes / 1_000_000).toFixed(1);
+
+  if (!total) return `Downloading... ${toMb(received)} MB`;
+
+  const ratio = Math.min(received / total, 1);
+  const filled = Math.round(ratio * width);
+  const bar = '#'.repeat(filled) + '-'.repeat(width - filled);
+  const pct = Math.round(ratio * 100);
+
+  return `[${bar}] ${pct}% (${toMb(received)}/${toMb(total)} MB)`;
+};
+
+export const downloadWithProgress = async (
+  url: string,
+  destPath: string,
+  onProgress?: ProgressListener,
+): Promise<void> => {
+  const res = await fetch(url);
+
+  if (!res.ok || !res.body)
+    throw new Error(
+      `Failed to download ${url} (${res.status} ${res.statusText})`,
+    );
+
+  const total = Number(res.headers.get('content-length')) || 0;
+  let received = 0;
+
+  const nodeStream = Readable.fromWeb(
+    res.body as unknown as WebReadableStream<Uint8Array>,
+  );
+
+  if (onProgress)
+    nodeStream.on('data', (chunk: Buffer) => {
+      received += chunk.length;
+      onProgress(received, total);
+    });
+
+  await pipeline(nodeStream, createWriteStream(destPath));
+};
+
+export const downloadBinaryWithProgress = (
+  url: string,
+  destPath: string,
+): Promise<void> =>
+  downloadWithProgress(url, destPath, (received, total) => {
+    if (!process.stdout.isTTY) return;
+
+    process.stdout.write(`\r${formatProgressBar(received, total)}`);
+
+    if (total && received >= total) process.stdout.write('\n');
+  });

--- a/cli/lib/update/index.ts
+++ b/cli/lib/update/index.ts
@@ -1,0 +1,5 @@
+export * from './binary';
+export * from './checksum';
+export * from './download';
+export * from './npm';
+export * from './version';

--- a/cli/lib/update/npm.ts
+++ b/cli/lib/update/npm.ts
@@ -1,0 +1,78 @@
+import { spawn } from 'child_process';
+import { logInfo, startLoader, stopWithFail, stopWithSuccess } from 'lib/log';
+import { fetchLatestNpmVersion, isNewerVersion } from './version';
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+// deadrop only publishes to the npm registry, but users may have
+// installed globally via npm, pnpm, yarn, or bun — always shelling out
+// to `npm install -g` risks updating a copy that isn't the one on PATH.
+// Markers match each PM's real global-install directory convention:
+// pnpm -> .../pnpm/global/..., yarn (classic) -> .../.config/yarn/global/...,
+// bun -> .../.bun/install/global/...
+const PM_MARKERS: Array<[marker: string, pm: PackageManager]> = [
+  ['pnpm', 'pnpm'],
+  ['yarn', 'yarn'],
+  ['.bun', 'bun'],
+];
+
+export const detectPackageManager = (
+  scriptPath: string = process.argv[1] ?? '',
+): PackageManager => {
+  const match = PM_MARKERS.find(([marker]) => scriptPath.includes(marker));
+
+  return match ? match[1] : 'npm';
+};
+
+export const getGlobalInstallCommand = (
+  pm: PackageManager,
+): { cmd: string; args: string[] } => {
+  switch (pm) {
+    case 'pnpm':
+      return { cmd: 'pnpm', args: ['add', '-g', 'deadrop@latest'] };
+    case 'yarn':
+      return { cmd: 'yarn', args: ['global', 'add', 'deadrop@latest'] };
+    case 'bun':
+      return { cmd: 'bun', args: ['add', '-g', 'deadrop@latest'] };
+    default:
+      return { cmd: 'npm', args: ['install', '-g', 'deadrop@latest'] };
+  }
+};
+
+const runGlobalInstall = (pm: PackageManager): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const { cmd, args } = getGlobalInstallCommand(pm);
+    const child = spawn(cmd, args, { stdio: 'ignore' });
+
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(`${cmd} ${args.join(' ')} exited with code ${code}`),
+        );
+    });
+  });
+
+export async function updateNpmInstall(
+  currentVersion: string,
+): Promise<void> {
+  const latest = await fetchLatestNpmVersion();
+
+  if (!isNewerVersion(latest, currentVersion)) {
+    logInfo(`Already on the latest version (v${currentVersion})`);
+    return;
+  }
+
+  const pm = detectPackageManager();
+
+  startLoader(`Updating via ${pm}...`);
+
+  try {
+    await runGlobalInstall(pm);
+    stopWithSuccess(`v${currentVersion} → v${latest}`);
+  } catch (err) {
+    stopWithFail(`Update failed: ${(err as Error).message}`);
+    throw err;
+  }
+}

--- a/cli/lib/update/version.ts
+++ b/cli/lib/update/version.ts
@@ -1,0 +1,38 @@
+import { gt } from 'semver';
+import {
+  GITHUB_LATEST_RELEASE_URL,
+  NPM_REGISTRY_LATEST_URL,
+} from 'lib/constants';
+
+// GitHub release tags are `deadrop@X.Y.Z` (see cli_publish_workflow.yml)
+export const parseGithubReleaseTag = (tag: string): string =>
+  tag.replace(/^deadrop@/, '');
+
+export const fetchLatestBinaryVersion = async (): Promise<string> => {
+  const res = await fetch(GITHUB_LATEST_RELEASE_URL);
+
+  if (!res.ok)
+    throw new Error(
+      `Failed to fetch latest release (${res.status} ${res.statusText})`,
+    );
+
+  const { tag_name: tag } = (await res.json()) as { tag_name: string };
+
+  return parseGithubReleaseTag(tag);
+};
+
+export const fetchLatestNpmVersion = async (): Promise<string> => {
+  const res = await fetch(NPM_REGISTRY_LATEST_URL);
+
+  if (!res.ok)
+    throw new Error(
+      `Failed to fetch latest npm version (${res.status} ${res.statusText})`,
+    );
+
+  const { version } = (await res.json()) as { version: string };
+
+  return version;
+};
+
+export const isNewerVersion = (latest: string, current: string): boolean =>
+  gt(latest, current);

--- a/cli/scripts/bun-build.ts
+++ b/cli/scripts/bun-build.ts
@@ -60,6 +60,12 @@ const figletFontPath = resolve(figletPkgDir, 'fonts', 'Standard.flf');
 const figletFontData = readFileSync(figletFontPath, 'utf8');
 envVars['FIGLET_STANDARD_FONT'] = JSON.stringify(figletFontData);
 
+// Baked in at build time so `deadrop update` can tell which pipeline
+// produced this artifact without a runtime check (typeof Bun would
+// misfire if Bun ever ends up interpreting the plain npm/esbuild build).
+envVars['process.env.DEADROP_INSTALL_METHOD'] =
+  JSON.stringify('binary');
+
 // Plugin: rewrite the `libsql` package's requireNative() so it loads the
 // .node file via a static absolute path instead of a dynamic
 // require(`@libsql/${target}`) that Bun's bundler can't trace.

--- a/cli/scripts/esbuild.js
+++ b/cli/scripts/esbuild.js
@@ -37,6 +37,9 @@ if (missing.length) {
         CLERK_PUBLISHABLE_KEY: process.env.CLERK_PUBLISHABLE_KEY,
         TURN_USERNAME: process.env.TURN_USERNAME,
         TURN_PWD: process.env.TURN_PWD,
+        // baked in at build time so `deadrop update` can tell which
+        // pipeline produced this artifact without a runtime check
+        DEADROP_INSTALL_METHOD: 'npm',
       }),
     ],
 

--- a/cli/tests/unit/update-binary.spec.ts
+++ b/cli/tests/unit/update-binary.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  releaseAssetUrl,
+  resolveReleaseAssetName,
+} from 'lib/constants';
+import { formatProgressBar } from 'lib/update/download';
+
+describe('resolveReleaseAssetName', () => {
+  it('builds the darwin arm64 asset name', () => {
+    expect(resolveReleaseAssetName('darwin', 'arm64')).toBe(
+      'deadrop-darwin-arm64',
+    );
+  });
+
+  it('builds the darwin x64 asset name', () => {
+    expect(resolveReleaseAssetName('darwin', 'x64')).toBe(
+      'deadrop-darwin-x64',
+    );
+  });
+
+  it('builds the linux arm64 asset name', () => {
+    expect(resolveReleaseAssetName('linux', 'arm64')).toBe(
+      'deadrop-linux-arm64',
+    );
+  });
+
+  it('builds the linux x64 asset name', () => {
+    expect(resolveReleaseAssetName('linux', 'x64')).toBe(
+      'deadrop-linux-x64',
+    );
+  });
+
+  it('throws for an unsupported platform', () => {
+    expect(() => resolveReleaseAssetName('win32', 'x64')).toThrow(
+      /Unsupported platform/,
+    );
+  });
+
+  it('throws for an unsupported architecture', () => {
+    expect(() => resolveReleaseAssetName('darwin', 'ia32')).toThrow(
+      /Unsupported platform/,
+    );
+  });
+});
+
+describe('releaseAssetUrl', () => {
+  it('builds the GitHub release download URL', () => {
+    expect(releaseAssetUrl('deadrop@1.2.3', 'deadrop-darwin-arm64')).toBe(
+      'https://github.com/dallen4/deadrop/releases/download/deadrop@1.2.3/deadrop-darwin-arm64',
+    );
+  });
+});
+
+describe('formatProgressBar', () => {
+  it('renders a filled bar at 100%', () => {
+    const bar = formatProgressBar(100, 100, 10);
+
+    expect(bar).toContain('100%');
+    expect(bar).toContain('##########');
+  });
+
+  it('renders a partial bar and byte counts', () => {
+    const bar = formatProgressBar(500_000, 1_000_000, 10);
+
+    expect(bar).toContain('50%');
+    expect(bar).toContain('0.5/1.0 MB');
+  });
+
+  it('falls back to a byte counter when total is unknown', () => {
+    const bar = formatProgressBar(2_000_000, 0);
+
+    expect(bar).toBe('Downloading... 2.0 MB');
+  });
+});

--- a/cli/tests/unit/update-checksum.spec.ts
+++ b/cli/tests/unit/update-checksum.spec.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  computeSha256,
+  parseChecksumFile,
+  verifyChecksum,
+} from 'lib/update/checksum';
+
+describe('parseChecksumFile', () => {
+  it('extracts the hash from a `sha256sum`-style file', () => {
+    expect(
+      parseChecksumFile('abc123  deadrop-darwin-arm64\n'),
+    ).toBe('abc123');
+  });
+
+  it('extracts the hash when there is no trailing filename', () => {
+    expect(parseChecksumFile('abc123\n')).toBe('abc123');
+  });
+});
+
+describe('computeSha256 / verifyChecksum', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'deadrop-update-test-'));
+  const filePath = join(dir, 'fixture.bin');
+  const content = 'deadrop update checksum fixture';
+  const expectedHash = createHash('sha256').update(content).digest('hex');
+
+  beforeAll(() => {
+    writeFileSync(filePath, content);
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('computes the sha256 hash of a file', async () => {
+    await expect(computeSha256(filePath)).resolves.toBe(expectedHash);
+  });
+
+  it('verifies a matching checksum', async () => {
+    await expect(verifyChecksum(filePath, expectedHash)).resolves.toBe(
+      true,
+    );
+  });
+
+  it('is case-insensitive when comparing checksums', async () => {
+    await expect(
+      verifyChecksum(filePath, expectedHash.toUpperCase()),
+    ).resolves.toBe(true);
+  });
+
+  it('rejects a mismatched checksum', async () => {
+    await expect(
+      verifyChecksum(filePath, '0'.repeat(64)),
+    ).resolves.toBe(false);
+  });
+});

--- a/cli/tests/unit/update-npm.spec.ts
+++ b/cli/tests/unit/update-npm.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectPackageManager,
+  getGlobalInstallCommand,
+} from 'lib/update/npm';
+
+describe('detectPackageManager', () => {
+  it('detects pnpm from a pnpm global install path', () => {
+    expect(
+      detectPackageManager(
+        '/Users/nieky/Library/pnpm/global/5/.pnpm/deadrop@1.0.0/dist/deadrop.js',
+      ),
+    ).toBe('pnpm');
+  });
+
+  it('detects yarn from a yarn global install path', () => {
+    expect(
+      detectPackageManager(
+        '/Users/nieky/.config/yarn/global/node_modules/deadrop/dist/deadrop.js',
+      ),
+    ).toBe('yarn');
+  });
+
+  it('detects bun from a bun global install path', () => {
+    expect(
+      detectPackageManager(
+        '/Users/nieky/.bun/install/global/node_modules/deadrop/dist/deadrop.js',
+      ),
+    ).toBe('bun');
+  });
+
+  it('defaults to npm when no other package manager marker is present', () => {
+    expect(
+      detectPackageManager(
+        '/usr/local/lib/node_modules/deadrop/dist/deadrop.js',
+      ),
+    ).toBe('npm');
+  });
+
+  it('defaults to npm for an empty path', () => {
+    expect(detectPackageManager('')).toBe('npm');
+  });
+});
+
+describe('getGlobalInstallCommand', () => {
+  it('builds the npm global install command', () => {
+    expect(getGlobalInstallCommand('npm')).toEqual({
+      cmd: 'npm',
+      args: ['install', '-g', 'deadrop@latest'],
+    });
+  });
+
+  it('builds the pnpm global install command', () => {
+    expect(getGlobalInstallCommand('pnpm')).toEqual({
+      cmd: 'pnpm',
+      args: ['add', '-g', 'deadrop@latest'],
+    });
+  });
+
+  it('builds the yarn global install command', () => {
+    expect(getGlobalInstallCommand('yarn')).toEqual({
+      cmd: 'yarn',
+      args: ['global', 'add', 'deadrop@latest'],
+    });
+  });
+
+  it('builds the bun global install command', () => {
+    expect(getGlobalInstallCommand('bun')).toEqual({
+      cmd: 'bun',
+      args: ['add', '-g', 'deadrop@latest'],
+    });
+  });
+});

--- a/cli/tests/unit/update-version.spec.ts
+++ b/cli/tests/unit/update-version.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchLatestBinaryVersion,
+  fetchLatestNpmVersion,
+  isNewerVersion,
+  parseGithubReleaseTag,
+} from 'lib/update/version';
+
+describe('parseGithubReleaseTag', () => {
+  it('strips the deadrop@ prefix from a release tag', () => {
+    expect(parseGithubReleaseTag('deadrop@1.2.3')).toBe('1.2.3');
+  });
+
+  it('leaves an already-bare version untouched', () => {
+    expect(parseGithubReleaseTag('1.2.3')).toBe('1.2.3');
+  });
+});
+
+describe('isNewerVersion', () => {
+  it('is true when latest is greater than current', () => {
+    expect(isNewerVersion('1.1.0', '1.0.0')).toBe(true);
+  });
+
+  it('is false when latest equals current', () => {
+    expect(isNewerVersion('1.0.0', '1.0.0')).toBe(false);
+  });
+
+  it('is false when latest is older than current', () => {
+    expect(isNewerVersion('0.9.0', '1.0.0')).toBe(false);
+  });
+});
+
+describe('fetchLatestBinaryVersion / fetchLatestNpmVersion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves the bare version from the GitHub releases API', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ tag_name: 'deadrop@2.0.0' }),
+      }),
+    );
+
+    await expect(fetchLatestBinaryVersion()).resolves.toBe('2.0.0');
+  });
+
+  it('throws when the GitHub releases API request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      }),
+    );
+
+    await expect(fetchLatestBinaryVersion()).rejects.toThrow(/404/);
+  });
+
+  it('resolves the version from the npm registry', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: '3.1.4' }),
+      }),
+    );
+
+    await expect(fetchLatestNpmVersion()).resolves.toBe('3.1.4');
+  });
+});

--- a/specs/cli-update-command.md
+++ b/specs/cli-update-command.md
@@ -1,0 +1,108 @@
+# CLI Update Command + install.sh Progress Bar
+
+## Context
+
+`deadrop` ships two ways:
+- **npm global install** (`npm i -g deadrop` / pnpm / yarn / bun) — runs under Node, resolves `dist/deadrop.js` built by `cli/scripts/esbuild.js`.
+- **Standalone binary** via `cli/install.sh` — downloads a Bun-compiled executable from GitHub Releases (`dallen4/deadrop`, tags `deadrop@X.Y.Z`, assets `deadrop-${os}-${arch}` + `.sha256`), built by `cli/scripts/bun-build.ts`.
+
+There is currently no update path for either install method — users reinstall manually. Goal: a `deadrop update` command that mirrors Claude Code's — run it, it tells you the previous and new version, and it's done — for **both** install methods. Secondary goal: a download progress bar for `install.sh`'s binary fetch, and (as a stretch) a real progress bar in `deadrop update`'s binary-download path.
+
+## Decisions made
+
+- **Support both install methods, auto-detected** — not npm-only or binary-only. install.sh is likely the primary "curl and go" path, so leaving it without an update story wasn't acceptable.
+- **Detection is build-time, not runtime.** A runtime check like `typeof Bun !== 'undefined'` (already used in `lib/util.ts`) detects which runtime is *executing* the code, not which pipeline *built* the artifact — if Bun ever interprets the plain npm/esbuild output, that check would misidentify an npm install as a binary install. Instead, bake `DEADROP_INSTALL_METHOD` in at build time (same mechanism already used for `FIGLET_STANDARD_FONT` / `DEADROP_API_URL` etc. via `environmentPlugin` in `esbuild.js` and `define` in `bun-build.ts`).
+- **install.sh progress bar: use curl's native `--progress-bar` for now.** A custom/fancier bar would need more shell scripting to maintain; native curl is zero-complexity and ships today. A nicer custom bar is desired eventually but explicitly deferred (see Open Questions).
+- **`deadrop update` progress UI differs by path:** binary-install path gets a real byte-level progress bar (streamed `fetch`, `Content-Length` vs. bytes read, no new dependency). npm-install path gets an Ora spinner only — a subprocess (`npm`/`pnpm`/etc.) doesn't give us byte-level progress to render.
+- **npm-path package manager detection: infer from install path, default npm.** `deadrop` only publishes to the npm registry, but users may have installed globally via npm, pnpm, yarn, or bun. Always shelling out to `npm install -g` risks leaving a stale/duplicate copy for pnpm/yarn/bun-global users. Instead, inspect `process.argv[1]` for `pnpm`/`yarn`/`.bun` substrings (matching each PM's real global-install directory convention — e.g. yarn classic's `.config/yarn/global`, not a literal `.yarn` folder) and use that PM's global-install command; fall back to `npm` if nothing matches. (Rejected: always-npm — too likely to update the wrong copy. Rejected: print-instructions-only — breaks the "just run it and you're done" goal.)
+- **No `--check`/`--dry-run` flag.** Not requested; keeping the command a single explicit action (YAGNI).
+
+## Open questions / deferred
+
+- **Windows binary self-update is not solved in this pass.** In-place executable swaps are unreliable on Windows while the process is running. `install.sh` itself never supported Windows (bash-only, `Darwin`/`Linux` case statement), so a Windows binary user only exists by manually downloading the `.exe` from Releases. For now, `deadrop update` on `win32` + binary install prints a message pointing back to the Releases page instead of attempting a swap. Revisit if Windows binary usage turns out to be non-trivial.
+- **A fancier/custom install.sh progress bar** (beyond curl's native `--progress-bar`) is wanted eventually but not scoped or designed here.
+
+## Install-method detection (build-time)
+
+- `cli/scripts/esbuild.js` — add `DEADROP_INSTALL_METHOD: 'npm'` to the existing `environmentPlugin` config.
+- `cli/scripts/bun-build.ts` — add `DEADROP_INSTALL_METHOD: 'binary'` to the `envVars` map (same `define` mechanism already used for `DEADROP_API_URL` etc.).
+- `actions/update.ts` reads it as `process.env.DEADROP_INSTALL_METHOD` — same `process.env.X` build-time-substitution pattern already used for `DEADROP_API_URL`/`DEADROP_APP_URL`/etc. on both pipelines, rather than a bare ambient global like `FIGLET_STANDARD_FONT` (that pattern exists specifically because `FIGLET_STANDARD_FONT` is intentionally *undefined* on the esbuild side; here we want a real value baked in on both sides, so reusing the `process.env.*` mechanism is more consistent with existing code).
+
+## Command
+
+New `cli/actions/update.ts`, registered in `core.ts`:
+
+```ts
+deadrop.command('update').action(update);
+```
+
+Thin action, same pattern as `login`/`logout`/`init`.
+
+### Binary-install path (`DEADROP_INSTALL_METHOD === 'binary'`)
+
+1. `GET https://api.github.com/repos/dallen4/deadrop/releases/latest` (same endpoint `install.sh` uses). Parse `tag_name` (`deadrop@X.Y.Z`), strip the prefix, compare to the running `version` (from `core.ts`) via `semver.gt()`.
+2. Not newer → print `Already on the latest version (v1.2.0)`, exit 0.
+3. `process.platform === 'win32'` → print the Releases-page fallback message (see Open Questions), exit 0.
+4. Otherwise:
+   - Resolve the asset URL exactly like `install.sh`: `deadrop-${os}-${arch}` + `.sha256` sibling.
+   - Stream the download via native `fetch` to a temp file (`os.tmpdir()`), rendering a real byte-progress bar: read `Content-Length`, track bytes consumed as chunks arrive, redraw a `[####----] 42% (1.2/2.9 MB)`-style line with `\r` (same terminal-redraw approach already used in `lib/log/text.ts`'s `printGrabberList`). No new dependency.
+   - Verify SHA-256 of the downloaded file against the `.sha256` asset (`node:crypto`).
+   - `chmod +x` the temp file, then `fs.renameSync(tmpPath, process.execPath)` — atomic replace. The currently-running process keeps executing off the unlinked old inode; nothing crashes mid-update.
+5. Print `v1.0.0 → v1.2.0`, exit 0.
+
+### npm-install path (`DEADROP_INSTALL_METHOD === 'npm'`)
+
+1. `GET https://registry.npmjs.org/deadrop/latest`, compare versions the same way.
+2. Not newer → same "already up to date" message.
+3. Detect package manager from `process.argv[1]` (substring match `pnpm`/`yarn`/`.bun`, default `npm`). Run that PM's global-install/update command as a child process.
+4. Show an Ora spinner ("Updating via pnpm...") while it runs.
+5. Print `v1.0.0 → v1.2.0`, exit 0.
+
+## install.sh
+
+Change the binary-download `curl -fsSL` to `curl -fsSL --progress-bar`. Leave the small GitHub API and `.sha256` fetches on `-fsSL` (silent) — only the big binary download gets a visible bar.
+
+## Errors & edge cases
+
+- Network failure fetching latest version/release metadata → clear error, exit non-zero, no filesystem changes.
+- Checksum mismatch → abort before `chmod`/`rename`, temp file discarded, exit non-zero.
+- `EACCES` writing to the binary's directory or npm's global dir → clear actionable error, exit non-zero.
+- Atomic rename means a failed download/verify never leaves a half-written binary in place — worst case, the update didn't happen and the old binary still runs.
+
+## Testing notes
+
+Vitest unit tests (`cli/tests/unit/`), mocking `fetch`/`fs`:
+- Version-diff decision (up to date vs. update available) via `semver`.
+- Package-manager detection given fake `process.argv[1]` values (pnpm/yarn/bun/none).
+- GitHub asset-URL construction for each OS/arch combination.
+- Checksum comparison (match/mismatch).
+
+Not unit tested (manual verification instead, consistent with `install.sh` also being untested):
+- The actual download-and-replace network/filesystem side effects.
+- The rendered progress bar output itself.
+- `install.sh`'s `--progress-bar` change (manual run).
+
+Manual verification plan:
+- [ ] Binary install (macOS): `deadrop update` from an older tagged binary shows a progress bar, verifies checksum, replaces itself, prints `vX → vY`, and the new binary runs (`deadrop --version`).
+- [ ] Binary install, already latest: prints "already on the latest version", no download.
+- [ ] npm install (global): `deadrop update` detects `npm`, runs `npm install -g deadrop@latest`, prints `vX → vY`.
+- [ ] pnpm global install: `deadrop update` detects `pnpm` from the install path and uses `pnpm add -g`, not `npm`.
+- [ ] `install.sh` fresh run on a clean machine: binary download shows curl's progress bar; checksum verification still passes.
+- [ ] Simulated checksum mismatch (binary path): update aborts, old binary untouched, non-zero exit.
+- [ ] `win32` + binary install: prints Releases-page fallback message, does not attempt a swap.
+
+## Implementation checklist
+
+- [x] Add `DEADROP_INSTALL_METHOD: 'npm'` to `cli/scripts/esbuild.js`'s `environmentPlugin` config
+- [x] Add `DEADROP_INSTALL_METHOD: 'binary'` to `cli/scripts/bun-build.ts`'s `envVars` map
+- [x] ~~Declare ambient `DEADROP_INSTALL_METHOD` constant~~ — reused the existing `process.env.*` define pattern instead (see Install-method detection note above); no separate ambient declaration needed
+- [x] Add GitHub repo / release constants to `cli/lib/constants.ts` (reuse `dallen4/deadrop`, asset naming convention shared with `install.sh`)
+- [x] Implement version-check helpers: GitHub latest-release fetch + npm registry latest fetch, both returning a comparable semver (`cli/lib/update/version.ts`)
+- [x] Implement binary-path update: asset URL resolution, streamed download with progress bar, checksum verification, atomic `rename` self-replace, `win32` fallback message (`cli/lib/update/binary.ts`, `download.ts`, `checksum.ts`)
+- [x] Implement npm-path update: package-manager detection from `process.argv[1]`, spawn PM's global-install command with Ora spinner (`cli/lib/update/npm.ts`)
+- [x] Create `cli/actions/update.ts` wiring both paths behind `DEADROP_INSTALL_METHOD`
+- [x] Register `update` command in `cli/core.ts`
+- [x] Update `cli/install.sh`: `curl -fsSL` → `curl -fsSL --progress-bar` for the binary download only
+- [x] Add Vitest unit tests: version-diff decision, PM detection, asset-URL construction, checksum comparison (47/47 passing)
+- [ ] Run manual verification plan above
+- [x] Update `cli/CLAUDE.md` command list to include `deadrop update`


### PR DESCRIPTION
## Summary

Adds a `deadrop update` command, mirroring how Claude Code's CLI updater works: run it, and it checks for a newer release, downloads and verifies it, and reports the version change. Also adds a download progress bar to `install.sh`. (Same change as #115, promoting `alpha` → `main`.)

- **Build-time install-method flag** (`c293dc4`): `DEADROP_INSTALL_METHOD` is baked in at build time (`'npm'` in `esbuild.js`, `'binary'` in `bun-build.ts`), the same way `DEADROP_API_URL` etc. already are. Avoids a runtime `typeof Bun` check, which would misidentify an npm install as a binary install if Bun ever ends up interpreting the plain esbuild output.
- **`deadrop update` command** (`9452710`): handles both install paths deadrop ships —
  - **binary** (installed via `install.sh`): fetches the latest GitHub release, streams the download with a byte-progress bar, verifies the SHA-256 checksum, then atomically self-replaces the running binary via `fs.renameSync`. Falls back to a Releases-page message on Windows, where an in-place swap of a running executable isn't reliable (`install.sh` itself never supported Windows either).
  - **npm** (installed via npm/pnpm/yarn/bun globally): fetches the latest npm registry version, detects which package manager was used from the resolved install path, and shells out to that PM's global-install command behind a spinner — avoids updating the wrong copy for pnpm/yarn/bun-global users.
  - New `cli/lib/update/` module: `version.ts`, `binary.ts`, `npm.ts`, `download.ts`, `checksum.ts`. `cli/actions/update.ts` is a thin wrapper registered as the `update` command.
- **`install.sh` progress bar** (`8c3f329`): binary download now uses `curl --progress-bar` instead of running silently.
- **Design spec + changeset** (`34561ab`): `specs/cli-update-command.md` documents the decisions (build-time detection, PM auto-detection, deferred items like a fancier install.sh bar and Windows binary self-update), and `.changeset/cli-update-command.md` declares `cli: minor`.

## Test plan

- [x] `pnpm vitest run --project cli` — 47/47 new/existing update-related tests passing (version-diff logic, PM detection, GitHub asset-URL construction per OS/arch, checksum verification)
- [x] Full monorepo `pnpm test` — 160/160 passing (pre-push hook)
- [x] `tsc --noEmit` on `cli/tsconfig.json` — no new type errors
- [x] CI green on #115 (`cross-platform-e2e` ×2, unit `test`, Playwright `test`, Vercel deploy)
- [ ] Manual: binary install update end-to-end (download, checksum, self-replace) against a real GitHub release
- [ ] Manual: npm/pnpm global install update end-to-end
- [ ] Manual: `install.sh` fresh run shows the progress bar