### PR TITLE
fix (ci): disable createGithubReleases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           version: pnpm changeset:version
           commit: 'chore: version packages'
           title: 'chore: version packages'
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

`changesets/action`'s release step has been crashing on every publish with:

```
Error: Package "deadrop" not found. This is probably a bug in the action, please open an issue
```

The `pnpm changeset:publish` script (`scripts/changeset-publish.js`) temporarily renames `cli/package.json`'s `name` to `"deadrop"` just for the `changeset publish` subprocess (since the workspace is `cli` but publishes to npm as `deadrop`), then reverts it in a `finally` block before returning control to `changesets/action`. The action gathers its workspace package list *before* that rename happens (recording `"cli"`), then tries to attach a GitHub Release to whatever it scraped from the publish subprocess's stdout (`"deadrop"`) — the names never match, and it throws.

Consequences: npm publish succeeds, but the crash happens immediately after, before the git tag gets pushed and before `release.yml`'s own "Trigger CLI binary release" step runs (it's gated on the now-failed job). Net effect: `deadrop@1.1.0` published to npm, but no tag, no CLI binaries, no GitHub Release — this has been happening on every release; past binary builds were all manual `workflow_dispatch`, never the automated path.

## Fix

Set `createGithubReleases: false` on the `changesets/action` step. We don't need this feature — `cli_publish_workflow.yml` already creates its own GitHub Release for the compiled binaries via `marvinpinto/action-automatic-releases`. Disabling it sidesteps the workspace/npm name mismatch entirely rather than trying to reconcile it.

## Test plan

- [x] YAML validated (`yaml.parse` via the `yaml` package already in `cli/`'s deps)
- [x] `pnpm test` — 160/160 passing (pre-push hook)
- [ ] Next real release run completes without the crash, tag gets pushed, and the CLI binary build triggers automatically