### PR TITLE
feat (cli): add deadrop inject command

### DIFF
--- a/.changeset/cli-inject-command.md
+++ b/.changeset/cli-inject-command.md
@@ -1,0 +1,13 @@
+---
+'cli': minor
+---
+
+Added a `deadrop inject -- <command>` command — runs a command with
+the active (or selected) vault's secrets injected directly into its
+environment. Secrets are decrypted in memory and never written to
+disk, replacing the export-to-`.env`-then-source pattern for local
+dev and CI/CD.
+
+Supports `-v/--vault`, `-e/--environment`, `-c/--config` (explicit
+config file, JSON or YAML, for CI), and `--no-override`. Forwards
+SIGINT/SIGTERM/SIGHUP to the child and exits with its exit code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Hono routes:
 
 ### CLI (`cli/`)
 
-- Commands: `drop`, `grab`, `init`, `login`, `logout`, `vault` (create/use/sync/export/import/delete), `secret` (add/remove)
+- Commands: `drop`, `grab`, `init`, `login`, `logout`, `update`, `inject`, `vault` (create/use/sync/export/import/delete), `secret` (add/remove)
 - Local secrets storage: Drizzle ORM + SQLite (libsql)
 - Build: esbuild → `dist/deadrop.js`; optional standalone binary via nexe
 

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -21,6 +21,7 @@ cli/
 ├── actions/              # Command handler implementations
 │   ├── drop.ts           # drop command → drives dropMachine (XState)
 │   ├── grab.ts           # grab command → drives grabMachine (XState)
+│   ├── inject.ts         # inject: run <cmd> with vault secrets as env vars, no file on disk
 │   ├── init.ts           # init: CLI setup wizard
 │   ├── login.ts          # login: Clerk auth
 │   ├── logout.ts
@@ -49,7 +50,8 @@ cli/
 │   ├── session.ts         # Session management helpers
 │   ├── crypto.ts          # CLI-specific crypto utilities
 │   ├── env.ts             # Env var resolution
-│   ├── config.ts          # CLI config file (~/.deadrop)
+│   ├── config.ts          # CLI config file (~/.deadrop); loadConfigFromPath for --config
+│   ├── process.ts         # runWithEnv: spawn a child with injected env, forward signals/exit code
 │   ├── files.ts           # File read/write helpers (file-mode drop/grab)
 │   ├── log/
 │   │   ├── index.ts       # Logger setup
@@ -92,6 +94,7 @@ deadrop logout
 deadrop update           # Update to the latest version (npm or standalone binary)
 deadrop drop            # Share a secret (drives dropMachine)
 deadrop grab            # Receive a secret (drives grabMachine)
+deadrop inject           # Run a command with vault secrets injected as env vars
 deadrop vault create    # Create a local vault
 deadrop vault use       # Switch active vault
 deadrop vault sync      # Sync vault ↔ .env file

--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -1,0 +1,62 @@
+import { initDBClient } from 'db/init';
+import { createSecretsHelpers } from '@shared/db/secrets';
+import { loadConfig, loadConfigFromPath } from 'lib/config';
+import { runWithEnv } from 'lib/process';
+import { logError, logInfo } from 'lib/log';
+
+type InjectOptions = {
+  vault?: string;
+  environment?: string;
+  config?: string;
+  override: boolean;
+  verbose?: boolean;
+};
+
+export async function inject(
+  command: string[],
+  options: InjectOptions,
+) {
+  if (!command?.length) {
+    logError('No command provided. Usage: deadrop inject -- <command>');
+    process.exit(1);
+  }
+
+  const { config } = options.config
+    ? await loadConfigFromPath(options.config)
+    : await loadConfig();
+
+  const vaultName = options.vault ?? config.active_vault.name;
+  const environment =
+    options.environment ?? config.active_vault.environment;
+
+  const vault = config.vaults[vaultName];
+  if (!vault) {
+    logError(`Vault '${vaultName}' not found in config.`);
+    process.exit(1);
+  }
+
+  const db = await initDBClient(vault.location, vault.cloud);
+  const { getAllSecrets } = createSecretsHelpers(vault, db);
+  const secrets = await getAllSecrets(environment);
+
+  const names = Object.keys(secrets);
+  logInfo(
+    `Injecting ${names.length} secret(s) from '${vaultName}' (${environment})`,
+  );
+  if (options.verbose && names.length)
+    logInfo(`Variables: ${names.join(', ')}`);
+
+  const [cmd, ...args] = command;
+  let exitCode = 0;
+  try {
+    exitCode = await runWithEnv(cmd, args, secrets, {
+      override: options.override,
+    });
+  } catch (err) {
+    logError((err as Error).message);
+    exitCode = 127;
+  } finally {
+    db.$client.close();
+  }
+  process.exit(exitCode);
+}

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -4,6 +4,7 @@ import init from 'actions/init';
 import login from 'actions/login';
 import { drop } from 'actions/drop';
 import { grab } from 'actions/grab';
+import { inject } from 'actions/inject';
 import { secretAdd } from 'actions/secret/add';
 import { secretRemove } from 'actions/secret/remove';
 import {
@@ -53,6 +54,17 @@ deadrop
   .description('grab a secret with a drop ID')
   .argument('<id>', 'drop session ID')
   .action(grab);
+
+deadrop
+  .command('inject')
+  .description('run a command with vault secrets injected as env vars')
+  .argument('<command...>', 'command to run (after --)')
+  .option('-v, --vault <name>', 'vault to inject')
+  .option('-e, --environment <env>', 'environment to inject')
+  .option('-c, --config <path>', 'explicit config file (JSON or YAML)')
+  .option('--no-override', 'let existing env vars win over vault values')
+  .option('--verbose', 'log injected variable names (never values)')
+  .action(inject);
 
 // vault commands
 

--- a/cli/lib/config.ts
+++ b/cli/lib/config.ts
@@ -2,8 +2,9 @@ import { CONFIG_FILE_NAME } from '@shared/lib/constants';
 import { DeadropConfig } from '@shared/types/config';
 import { cosmiconfig, CosmiconfigResult } from 'cosmiconfig';
 import { existsSync } from 'fs';
-import { writeFile } from 'fs/promises';
-import { stringify } from 'yaml';
+import { readFile, writeFile } from 'fs/promises';
+import { extname } from 'path';
+import { parse, stringify } from 'yaml';
 import { displayWelcomeMessage, logError, logInfo } from './log';
 import { initConfig as baseInitConfig } from '@shared/lib/vault';
 
@@ -27,6 +28,21 @@ export const loadConfig = async (): Promise<CustomConfigResult> => {
   }
 
   return configFile;
+};
+
+export const loadConfigFromPath = async (
+  path: string,
+): Promise<{ config: DeadropConfig }> => {
+  const raw = await readFile(path, 'utf-8');
+  const config: DeadropConfig =
+    extname(path) === '.json' ? JSON.parse(raw) : parse(raw);
+
+  if (!config?.active_vault || !config?.vaults) {
+    logError(`Config at '${path}' is missing 'active_vault' or 'vaults'.`);
+    process.exit(1);
+  }
+
+  return { config };
 };
 
 export const initConfig = async (defaultVaultPath: string) =>

--- a/cli/lib/process.ts
+++ b/cli/lib/process.ts
@@ -1,0 +1,41 @@
+import { spawn } from 'child_process';
+import { constants } from 'os';
+
+const FORWARDED: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+
+export function runWithEnv(
+  cmd: string,
+  args: string[],
+  secrets: Record<string, string>,
+  { override = true }: { override?: boolean } = {},
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const env = override
+      ? { ...process.env, ...secrets }
+      : { ...secrets, ...process.env };
+
+    const child = spawn(cmd, args, {
+      env,
+      stdio: 'inherit',
+      shell: false,
+    });
+
+    const forward = (sig: NodeJS.Signals) => child.kill(sig);
+    FORWARDED.forEach((s) => process.on(s, forward));
+    const cleanup = () =>
+      FORWARDED.forEach((s) => process.off(s, forward));
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      cleanup();
+      if (err.code === 'ENOENT')
+        reject(new Error(`Command not found: ${cmd}`));
+      else reject(err);
+    });
+
+    child.on('exit', (code, signal) => {
+      cleanup();
+      if (signal) resolve(128 + (constants.signals[signal] ?? 0));
+      else resolve(code ?? 0);
+    });
+  });
+}

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runWithEnv } from 'lib/process';
+
+describe('runWithEnv', () => {
+  it('injects secrets into the child process env', async () => {
+    const exitCode = await runWithEnv(
+      'node',
+      ['-e', 'process.exit(process.env.FOO === "bar" ? 0 : 7)'],
+      { FOO: 'bar' },
+    );
+    expect(exitCode).toEqual(0);
+  });
+
+  it('does not inject a mismatched value', async () => {
+    const exitCode = await runWithEnv(
+      'node',
+      ['-e', 'process.exit(process.env.FOO === "bar" ? 0 : 7)'],
+      { FOO: 'nope' },
+    );
+    expect(exitCode).toEqual(7);
+  });
+
+  it('lets vault values override existing process env by default', async () => {
+    process.env.FOO = 'existing';
+    const exitCode = await runWithEnv(
+      'node',
+      ['-e', 'process.exit(process.env.FOO === "secret" ? 0 : 7)'],
+      { FOO: 'secret' },
+    );
+    delete process.env.FOO;
+    expect(exitCode).toEqual(0);
+  });
+
+  it('lets existing process env win with override: false', async () => {
+    process.env.FOO = 'existing';
+    const exitCode = await runWithEnv(
+      'node',
+      ['-e', 'process.exit(process.env.FOO === "existing" ? 0 : 7)'],
+      { FOO: 'secret' },
+      { override: false },
+    );
+    delete process.env.FOO;
+    expect(exitCode).toEqual(0);
+  });
+
+  it('rejects when the command is not found', async () => {
+    await expect(
+      runWithEnv('definitely-not-a-real-bin-xyz', [], {}),
+    ).rejects.toThrow('Command not found');
+  });
+});
+
+vi.mock('lib/log', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+vi.mock('db/init', () => ({
+  initDBClient: vi.fn(),
+}));
+
+vi.mock('@shared/db/secrets', () => ({
+  createSecretsHelpers: vi.fn(),
+}));
+
+vi.mock('lib/config', () => ({
+  loadConfig: vi.fn(),
+  loadConfigFromPath: vi.fn(),
+}));
+
+describe('inject', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exits 1 with no command', async () => {
+    const { logError } = await import('lib/log');
+    const { inject } = await import('actions/inject');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+
+    await expect(inject([], { override: true })).rejects.toThrow('exit');
+
+    expect(logError).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('resolves the active vault/environment, runs the command, and closes the db', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } = await import(
+      '@shared/db/secrets'
+    );
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    const close = vi.fn();
+    const secrets = { FOO: 'bar' };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'dev' },
+        vaults: { default: { location: './vault.db', environments: {} } },
+      },
+    } as any);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue(secrets),
+    } as any);
+    const runWithEnvSpy = vi
+      .spyOn(processModule, 'runWithEnv')
+      .mockResolvedValue(3);
+
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await inject(['node', '-e', 'process.exit(3)'], { override: true });
+
+    expect(initDBClient).toHaveBeenCalledWith('./vault.db', undefined);
+    expect(runWithEnvSpy).toHaveBeenCalledWith(
+      'node',
+      ['-e', 'process.exit(3)'],
+      secrets,
+      { override: true },
+    );
+    expect(close).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(3);
+    exitSpy.mockRestore();
+    runWithEnvSpy.mockRestore();
+  });
+
+  it('exits 127 with a clean error when the command is not found', async () => {
+    const { logError } = await import('lib/log');
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } = await import(
+      '@shared/db/secrets'
+    );
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    const close = vi.fn();
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'dev' },
+        vaults: { default: { location: './vault.db', environments: {} } },
+      },
+    } as any);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue({}),
+    } as any);
+    const runWithEnvSpy = vi
+      .spyOn(processModule, 'runWithEnv')
+      .mockRejectedValue(new Error('Command not found: nope'));
+
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await inject(['nope'], { override: true });
+
+    expect(logError).toHaveBeenCalledWith('Command not found: nope');
+    expect(close).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(127);
+    exitSpy.mockRestore();
+    runWithEnvSpy.mockRestore();
+  });
+});

--- a/specs/cli-inject-command.md
+++ b/specs/cli-inject-command.md
@@ -1,0 +1,309 @@
+# Spec: `deadrop inject` CLI command
+
+> Self-contained build spec for a single Claude Code session (sized for Haiku or Sonnet at
+> medium effort). Builds the `deadrop inject` subcommand. A GitHub Action that wraps this
+> command is a deliberate follow-up, not part of this session.
+
+## Context
+
+deadrop vaults hold secrets encrypted client-side (Turso-synced, server never sees plaintext).
+Today the only way to get them into a process is `deadrop vault export`, which writes a `.env`
+file to disk — a plaintext artifact that lingers and has to be cleaned up. For CI/CD and local
+dev we want to run a command with the vault's secrets injected directly into its environment,
+with no file on disk.
+
+`specs/pricing-tiers.md` (§"Inject flow (CI-side, `deadrop inject -- pnpm build`)" and
+"Future Work") specifies this command: `deadrop inject -- <cmd>` pulls the vault, decrypts
+locally, injects env vars into a wrapped child process, and tears down on exit. It is listed
+as not-yet-built. This session builds it.
+
+This is the prerequisite for a future `deadrop-inject` GitHub Action: the action will be a thin
+wrapper that downloads the already-published `deadrop` binary (see `cli_publish_workflow.yml`)
+and calls `deadrop inject`, so no compiled bundle ever needs committing. That action is out of
+scope here — see "Follow-ups".
+
+## Scope
+
+**In scope:** the `deadrop inject [options] -- <command...>` subcommand, reusing the existing
+config-load + cloud-sync + decrypt path. Works against any vault the config already describes
+(local, or cloud-synced via the Turso token already stored in config) — `deadrop login` is not
+required when the config is complete (the CI case).
+
+**Out of scope (document as follow-ups, do not build):**
+- Worker `/service-tokens/exchange` + short-lived Turso token exchange (v1 uses the long-lived
+  token already in the vault config; note the hardening path).
+- Tier/feature gating (`ci_tokens`) — the plan-claims plumbing isn't in the CLI yet.
+- The GitHub Action wrapper and any `--github-env`/`::add-mask::` output mode.
+
+## Command design
+
+```
+deadrop inject [options] -- <command...>
+
+Run <command> with the active (or selected) vault's secrets injected as environment
+variables. Secrets are decrypted in-memory and never written to disk.
+
+Options:
+  -v, --vault <name>          vault to inject (default: config active_vault.name)
+  -e, --environment <env>     environment to inject (default: config active_vault.environment)
+  -c, --config <path>         load an explicit config file (JSON or YAML) instead of the
+                              auto-discovered .deadroprc — the bridge for CI / the future action
+      --no-override           let pre-existing process env vars win over vault values
+                              (default: vault values override process env)
+      --verbose               log injected variable NAMES (never values)
+
+Examples:
+  deadrop inject -- pnpm build
+  deadrop inject -v prod -e production -- node server.js
+  deadrop inject --config ./deadrop-ci.json -- ./deploy.sh
+```
+
+### `--` separator (Commander semantics — important)
+Register the command with a variadic argument: `.argument('<command...>', '…')`. Commander
+treats everything after a standalone `--` as positional operands (not parsed as deadrop
+options), so `deadrop inject -v prod -- pnpm build --watch` parses `{ vault: 'prod' }` and
+passes `['pnpm','build','--watch']` to the action — the child's own `--watch` flag is safe.
+Require the `--`; if `command` is empty, error out with usage and exit 1.
+
+### Env merge + exit semantics
+- Default (`override` true): child env = `{ ...process.env, ...secrets }` (vault wins).
+- `--no-override`: `{ ...secrets, ...process.env }` (existing env wins).
+- Spawn with `stdio: 'inherit'`, `shell: false` (no shell-injection surface; users needing
+  shell features run `-- sh -c "…"`).
+- Forward `SIGINT`/`SIGTERM`/`SIGHUP` to the child; wait for it to exit, then exit the CLI with
+  the child's exit code (or `128 + signal` if it was signalled). ENOENT (command not found) →
+  clear error, exit 127.
+- Never log secret values. Log only a count by default; `--verbose` adds names.
+
+## Files
+
+### New
+- `cli/actions/inject.ts` — the `inject(command: string[], options: InjectOptions)` handler.
+  Mirrors `cli/actions/vault/export.ts` for load+decrypt, then spawns instead of writing a file.
+  ```ts
+  import { initDBClient } from 'db/init';
+  import { createSecretsHelpers } from '@shared/db/secrets';
+  import { loadConfig, loadConfigFromPath } from 'lib/config';
+  import { runWithEnv } from 'lib/process';
+  import { logError, logInfo } from 'lib/log';
+
+  type InjectOptions = {
+    vault?: string;
+    environment?: string;
+    config?: string;
+    override: boolean;   // commander sets this false when --no-override is passed
+    verbose?: boolean;
+  };
+
+  export async function inject(command: string[], options: InjectOptions) {
+    if (!command?.length) {
+      logError('No command provided. Usage: deadrop inject -- <command>');
+      process.exit(1);
+    }
+
+    const { config } = options.config
+      ? await loadConfigFromPath(options.config)
+      : await loadConfig();
+
+    const vaultName = options.vault ?? config.active_vault.name;
+    const environment =
+      options.environment ?? config.active_vault.environment;
+
+    const vault = config.vaults[vaultName];
+    if (!vault) {
+      logError(`Vault '${vaultName}' not found in config.`);
+      process.exit(1);
+    }
+
+    const db = await initDBClient(vault.location, vault.cloud);
+    const { getAllSecrets } = createSecretsHelpers(vault, db);
+    const secrets = await getAllSecrets(environment);
+
+    const names = Object.keys(secrets);
+    logInfo(
+      `Injecting ${names.length} secret(s) from '${vaultName}' (${environment})`,
+    );
+    if (options.verbose && names.length)
+      logInfo(`Variables: ${names.join(', ')}`);
+
+    const [cmd, ...args] = command;
+    let exitCode = 0;
+    try {
+      exitCode = await runWithEnv(cmd, args, secrets, {
+        override: options.override,
+      });
+    } finally {
+      db.$client.close();
+    }
+    process.exit(exitCode);
+  }
+  ```
+- `cli/lib/process.ts` — `runWithEnv` child-process helper (separate for unit-testability).
+  ```ts
+  import { spawn } from 'child_process';
+
+  const FORWARDED: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+
+  export function runWithEnv(
+    cmd: string,
+    args: string[],
+    secrets: Record<string, string>,
+    { override = true }: { override?: boolean } = {},
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const env = override
+        ? { ...process.env, ...secrets }
+        : { ...secrets, ...process.env };
+
+      const child = spawn(cmd, args, {
+        env,
+        stdio: 'inherit',
+        shell: false,
+      });
+
+      const forward = (sig: NodeJS.Signals) => child.kill(sig);
+      FORWARDED.forEach((s) => process.on(s, forward));
+      const cleanup = () =>
+        FORWARDED.forEach((s) => process.off(s, forward));
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        cleanup();
+        if (err.code === 'ENOENT') {
+          reject(new Error(`Command not found: ${cmd}`));
+        } else reject(err);
+      });
+
+      child.on('exit', (code, signal) => {
+        cleanup();
+        if (signal)
+          resolve(128 + (require('os').constants.signals[signal] ?? 0));
+        else resolve(code ?? 0);
+      });
+    });
+  }
+  ```
+- `cli/tests/unit/inject.spec.ts` — see Testing.
+
+### Modified
+- `cli/core.ts` — register the command (place after `grab`, before the vault group):
+  ```ts
+  import { inject } from 'actions/inject';
+
+  deadrop
+    .command('inject')
+    .description('run a command with vault secrets injected as env vars')
+    .argument('<command...>', 'command to run (after --)')
+    .option('-v, --vault <name>', 'vault to inject')
+    .option('-e, --environment <env>', 'environment to inject')
+    .option('-c, --config <path>', 'explicit config file (JSON or YAML)')
+    .option('--no-override', 'let existing env vars win over vault values')
+    .option('--verbose', 'log injected variable names (never values)')
+    .action(inject);
+  ```
+- `cli/lib/config.ts` — add `loadConfigFromPath` (explicit-file loader for `--config`, the CI
+  bridge). Returns the same `{ config }` shape as `loadConfig`. Parse `.json` via `JSON.parse`,
+  otherwise YAML (`parse` from `yaml`, already a dep). Validate it has `active_vault` + `vaults`;
+  `logError` + exit 1 if malformed or missing.
+- `cli/CLAUDE.md` — add `deadrop inject` to the command list.
+
+### Spec/doc
+- Update `specs/pricing-tiers.md` "Future Work" to note `deadrop inject` is built and what
+  remains (service-token exchange, action wrapper, tier gating).
+
+## Reused code (do not reimplement)
+- `loadConfig` — `cli/lib/config.ts:18`
+- `initDBClient(location, cloud)` — `cli/db/init.ts` (does the libSQL local-file +
+  cloud-replica sync; whatever works for `vault export`/`sync` works here unchanged)
+- `createSecretsHelpers(vault, db).getAllSecrets(environment)` — `shared/db/secrets.ts:65`
+  (queries the `secrets` table and decrypts each row via `unwrapSecret`)
+- `logInfo` / `logError` — `cli/lib/log`
+- The whole load+decrypt sequence is copied from `cli/actions/vault/export.ts`.
+
+## Notes / gotchas for the implementer
+- The handler signature is `(command: string[], options)` because of the variadic
+  `<command...>` argument — Commander passes the variadic as the first action param.
+- `--no-override` makes Commander populate `options.override = false` (camelCased, negated).
+  Type `InjectOptions.override` as required `boolean`.
+- Do NOT delete any DB file on teardown — `vault.location` may be the user's real persistent
+  vault. Teardown is just `db.$client.close()`. (Ephemeral CI replica cleanup is the runner's
+  job, handled later by the action.)
+- `formatCloudSyncUrl` (`shared/lib/util.ts`) reads `process.env.TURSO_ORGANIZATION`; cloud
+  inject inherits the same requirement/behavior as `vault export`. Don't try to "fix" sync here
+  — keep parity with export. Flag in the follow-ups that the CI config may need to carry a
+  resolved sync URL so the action doesn't depend on that env var.
+- Prettier: 70-char width, single quotes, semicolons, trailing commas (`.prettierrc`).
+
+## Testing (`cli/tests/unit/inject.spec.ts`, vitest)
+1. **Real env-injection round-trip (no mocks) — the key test.** Call `runWithEnv('node',
+   ['-e', 'process.exit(process.env.FOO === "bar" ? 0 : 7)'], { FOO: 'bar' })` and assert it
+   resolves `0`; with `{ FOO: 'nope' }` assert `7`. Proves secrets reach the child and the exit
+   code is forwarded.
+2. **Override semantics.** With `process.env.FOO` pre-set, assert default (`override: true`)
+   makes the child see the secret value, and `override: false` makes it see the pre-set value
+   (use the same `node -e` exit-code probe).
+3. **Command not found.** `runWithEnv('definitely-not-a-real-bin-xyz', [], {})` rejects with a
+   "Command not found" error.
+4. **Empty command guard.** `inject([], opts)` calls `process.exit(1)` (spy on `process.exit`
+   and `logError`).
+5. **Handler wiring (mocked).** Mock `loadConfig`, `initDBClient`, and `createSecretsHelpers`
+   (or `getAllSecrets`) to return a fixed map; mock `runWithEnv`; assert it's called with the
+   resolved vault/environment and that `db.$client.close()` runs even when the child exits
+   nonzero.
+
+Match existing test style in `cli/tests/unit/` (crypto.spec.ts) and `cli/vitest.config.mts`.
+
+## Verification (end-to-end)
+1. `pnpm cli:build` (esbuild → `dist/deadrop.js`).
+2. `deadrop init` then `deadrop vault create demo`; `deadrop secret add FOO bar`.
+3. `deadrop inject -- node -e "console.log(process.env.FOO)"` prints `bar`.
+4. `deadrop inject -- node -e "process.exit(3)"; echo $?` prints `3` (exit-code passthrough).
+5. `deadrop inject -- pnpm build --help` — the child's `--help` is not swallowed by deadrop.
+6. `deadrop inject -- sleep 30`, press Ctrl-C — child dies, no orphan process, CLI exits.
+7. `--config ./deadrop-ci.json` against a cloud vault config injects its secrets.
+8. `pnpm -F cli test` passes.
+
+## Follow-ups (not this session)
+
+An earlier draft of this pipeline-helpers follow-on proposed a different command shape
+(`deadrop inject --format env`, printing `KEY=value` to stdout) paired with a new "deadrop
+keys" Clerk-API-key auth mechanism for non-interactive CI use. This spec's actual design
+(wrap-and-spawn, `deadrop inject -- <cmd>`,
+no browser login needed when the config already carries a stored Turso token) supersedes that
+for the *local/CI-config-present* case. **Open question, not yet resolved:** is a separate
+"deadrop keys" auth mechanism still needed for teams who want to provision CI access without
+sharing/committing a full vault config (i.e. a scoped, revocable credential handed to CI rather
+than the whole config)? Decide before building the GitHub Action below — it changes the
+action's auth story.
+
+- `deadrop-inject` GitHub Action: composite action that downloads the published `deadrop`
+  binary and runs `deadrop inject` (or a `--github-env` mode that writes `$GITHUB_ENV` and
+  emits `::add-mask::`). No committed bundle. Needs a small GitHub-env output mode in the CLI.
+  ```yaml
+  - uses: dallen4/deadrop-action@v1
+    with:
+      key: ${{ secrets.DEADROP_KEY }}   # pending the open question above
+      vault: production
+  ```
+- GitLab CI and CircleCI: thin wrappers (orb / include template) following the same pattern
+  as the GitHub Action. Lower priority — ship the GitHub Action first.
+- Secrets masked in CI logs (no plaintext values exposed in job output) — verify whatever the
+  chosen output mode is (`$GITHUB_ENV` write, `::add-mask::`, etc.) actually masks, not just
+  avoids printing.
+- Worker `/service-tokens` issue/revoke/exchange + short-lived Turso token TTL (two-factor
+  hardening; replaces the long-lived token in the CI config).
+- Tier gating: gate `deadrop inject` behind the `ci_tokens` feature once plan-claim plumbing
+  lands in the CLI (`shared/config/plans.ts`).
+- Documentation: `/docs/features/cli` under a CI/CD section, once the action ships.
+- GitHub Actions Marketplace listing for the composite action.
+
+### Acceptance criteria (from the original issue, still applicable to the action phase)
+- [ ] `deadrop inject` authenticates non-interactively in CI (resolve the open auth question
+      above first)
+- [ ] Secrets are masked in CI logs
+- [ ] GitHub Actions action published to the Marketplace
+- [ ] Documented in `/docs/features/cli`
+- [ ] GitLab CI template and CircleCI orb (stretch)
+
+### Related
+- #25 API key auth strategy
+- PR #71 (original `inject.ts` proof of concept, precedes this spec's design)

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -82,7 +82,7 @@ All three implement the same cryptographic protocol and can interoperate. For ex
 
 ### What's the difference between the web app, CLI, and VS Code extension?
 
-The web app is the easiest entry point and requires zero setup. The CLI is best for scripting, automation, and dropping files from your terminal. It also unlocks CI/CD service tokens on paid plans. The VS Code extension brings drop, grab, and vault access into your editor without context-switching.
+The web app is the easiest entry point and requires zero setup. The CLI is best for scripting, automation, dropping files from your terminal, and injecting vault secrets into CI/CD jobs (`deadrop inject`). It also unlocks CI/CD service tokens on paid plans. The VS Code extension brings drop, grab, and vault access into your editor without context-switching.
 
 ## 🗄️ Vaults
 

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -3,7 +3,7 @@ import { INSTALL_COMMAND } from 'molecules/HeroBanner';
 
 # ⌨️ deadrop CLI
 
-The CLI gives you everything the web app does (dropping and grabbing) plus local and cloud-synced vaults for secret storage and a `.env` sync workflow that fits into scripts and CI/CD pipelines.
+The CLI gives you everything the web app does (dropping and grabbing) plus local and cloud-synced vaults for secret storage, a `.env` sync workflow, and `inject` for running scripts and CI/CD jobs with vault secrets in their environment, no file on disk.
 
 ## 📦 Installation
 
@@ -177,6 +177,32 @@ deadrop vault import ./.env.production
 
 Remove a vault from config and delete its database file. This is destructive and cannot be undone.
 
+### `inject`
+
+Run a command with a vault's secrets injected directly into its environment. Secrets are decrypted in memory and never written to disk, so there's no `.env` file to clean up.
+
+```
+deadrop inject [options] -- <command...>
+```
+
+| Option | Description |
+|---|---|
+| `-v, --vault <name>` | Vault to inject (default: the active vault). |
+| `-e, --environment <env>` | Environment to inject (default: the active vault's environment). |
+| `-c, --config <path>` | Load an explicit config file (JSON or YAML) instead of the auto-discovered config, for CI. |
+| `--no-override` | Let pre-existing environment variables win over vault values (default: vault values win). |
+| `--verbose` | Log the names of injected variables. Values are never logged. |
+
+The `--` separator is required. Everything after it is passed straight through to your command, so its own flags are safe:
+
+```
+deadrop inject -- pnpm build
+deadrop inject -v prod -e production -- node server.js
+deadrop inject -- pnpm build --watch   # --watch reaches pnpm, not deadrop
+```
+
+The child process exits with the wrapped command's exit code, and Ctrl-C/SIGTERM are forwarded to it. `deadrop login` isn't required as long as your config already has what it needs (the CI case, via `--config`).
+
 ### `secret`
 
 Manage secrets in the active vault.
@@ -216,6 +242,12 @@ eval "$(deadrop vault export work)"
 
 ```
 DB_URL=$(deadrop grab <drop_id>) ./deploy.sh
+```
+
+**Run CI/CD steps with vault secrets, no file on disk.** `inject` replaces the export-to-`.env`-then-source pattern:
+
+```
+deadrop inject --config ./deadrop-ci.json -- pnpm build
 ```
 
 ## 🔗 Related

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -30,7 +30,11 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 ### Surfaces
 
 - **Web app**: `deadrop.io`, installable as a PWA
-- **CLI**: drop, grab, vault, secret commands. Available on npm and via the install script
+- **CLI**: drop, grab, vault, secret, inject commands. Available on npm and via the install script
+
+### CI/CD
+
+- **`deadrop inject`**: run a command with a vault's secrets injected into its environment, no file on disk. See the [CLI docs](/docs/features/cli) for usage.
 
 ## 🧪 Experimental
 
@@ -75,8 +79,8 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 ### CI/CD
 
-- **Service tokens** (Supporter+): non-interactive vault access for build pipelines. [#62](https://github.com/dallen4/deadrop/issues/62) [#25](https://github.com/dallen4/deadrop/issues/25)
-- **Pipeline injection helpers**: drop-in actions/steps for GitHub Actions, GitLab CI, CircleCI.
+- **Service tokens** (Supporter+): short-lived, revocable non-interactive vault access for build pipelines, replacing the long-lived token in a CI config. [#62](https://github.com/dallen4/deadrop/issues/62) [#25](https://github.com/dallen4/deadrop/issues/25)
+- **GitHub Action**: composite action wrapping `deadrop inject`, with masked log output. GitLab CI template and CircleCI orb to follow.
 
 ### Distribution
 


### PR DESCRIPTION
## Summary
- Adds `deadrop inject -- <command>`: runs a command with the active (or selected) vault's secrets injected into its environment, decrypted in memory and never written to disk
- Supports `-v/--vault`, `-e/--environment`, `-c/--config` (explicit config file, JSON or YAML, for CI), and `--no-override`
- Forwards SIGINT/SIGTERM/SIGHUP to the child; exits with the child's exit code (128+signal if signalled, 127 on command-not-found)
- Adds `loadConfigFromPath` to `cli/lib/config.ts` as the CI bridge for `--config`
- Docs: CLI command reference, FAQ, features/roadmap page, and root `CLAUDE.md` updated; spec + changeset included

## Test plan
- [x] `pnpm -F cli test` — unit tests for `runWithEnv` (real spawn round-trip, override semantics, ENOENT) and the `inject` handler (empty command, wiring, ENOENT → 127)
- [x] `pnpm cli:build` then manually verified: secret injection, exit-code passthrough, `--verbose`, `--no-override`, `--config` with a JSON file, SIGINT forwarding (child dies, CLI exits 130), and `--` protecting the child's own flags (`node --version` after `--`)
- [x] Full monorepo `pnpm test` (168 tests) passes via pre-push hook
- [x] `pnpm -F web build` — docs pages compile cleanly