### PR TITLE
feat: CLI keychain auth + whoami, docs fixes, CI updates

### DIFF
--- a/.changeset/docs-updates.md
+++ b/.changeset/docs-updates.md
@@ -1,0 +1,8 @@
+---
+'web': patch
+---
+
+Docs fixes and formatting updates: resolved an install-command
+injection issue and several broken/missing imports on the docs pages,
+refreshed FAQ/features/overview content, and documented the new
+`deadrop whoami` command and OS-keychain credential storage.

--- a/.changeset/keychain-auth-whoami.md
+++ b/.changeset/keychain-auth-whoami.md
@@ -1,0 +1,14 @@
+---
+'cli': minor
+---
+
+Credentials are now stored in the OS keychain (macOS Keychain, Linux
+Secret Service via `libsecret`, Windows Credential Vault) instead of a
+plaintext `.deadrop/creds` file. Existing plaintext credentials are
+removed automatically on first run after upgrading, with a prompt to
+sign in again.
+
+Added `deadrop whoami` to check sign-in status without a full
+login/logout cycle. `deadrop login` failures now point at the actual
+platform-specific fix (libsecret on Linux, the OS keychain access
+prompt on macOS/Windows) instead of a Linux-only message.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/cli_publish_workflow.yml
+++ b/.github/workflows/cli_publish_workflow.yml
@@ -33,9 +33,9 @@ jobs:
             bun-target: bun-windows-x64
             artifact-name: deadrop-windows-x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -78,7 +78,7 @@ jobs:
             shasum -a 256 "$f" > "$f.sha256"
           fi
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact-name }}
           path: cli/dist/${{ matrix.artifact-name }}*
@@ -89,7 +89,7 @@ jobs:
     needs: cli-compile-binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,6 @@ jobs:
           else
             echo "deadrop package not in published set; skipping binary build"
           fi
+      - name: Restore cli/package.json name
+        if: always()
+        run: git checkout -- cli/package.json

--- a/cli/actions/logout.ts
+++ b/cli/actions/logout.ts
@@ -1,9 +1,6 @@
-import { existsSync } from 'fs';
-import { unlink } from 'fs/promises';
 import { createClerkClient } from 'lib/auth/clerk';
-import { STORAGE_DIR_NAME } from '@shared/lib/constants';
+import { clearSession } from 'lib/auth/cache';
 import { logInfo } from 'lib/log';
-import { cwd } from 'process';
 
 export default async function logout() {
   const clerkClient = await createClerkClient();
@@ -18,9 +15,7 @@ export default async function logout() {
 
   await clerkClient.signOut();
 
-  const authCachePath = `${cwd()}/${STORAGE_DIR_NAME}/creds`;
-
-  if (existsSync(authCachePath)) await unlink(authCachePath);
+  await clearSession();
 
   logInfo('Successfully signed out!');
 

--- a/cli/actions/whoami.ts
+++ b/cli/actions/whoami.ts
@@ -1,0 +1,20 @@
+import { createClerkClient } from 'lib/auth/clerk';
+import { logInfo } from 'lib/log';
+
+export default async function whoami() {
+  const clerkClient = await createClerkClient();
+
+  if (!clerkClient.session) {
+    logInfo(
+      `You're not signed in.\nRun \`deadrop login\` to get started.`,
+    );
+
+    return process.exit(0);
+  }
+
+  logInfo(
+    `Signed in as ${clerkClient.session.user.emailAddresses[0]}`,
+  );
+
+  process.exit(0);
+}

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -16,6 +16,7 @@ import {
   vaultUse,
 } from 'actions/vault';
 import logout from 'actions/logout';
+import whoami from 'actions/whoami';
 import update from 'actions/update';
 import { displayWelcomeMessage } from 'lib/log';
 
@@ -35,6 +36,11 @@ deadrop.command('init').action(init);
 deadrop.command('login').action(login);
 
 deadrop.command('logout').action(logout);
+
+deadrop
+  .command('whoami')
+  .description('check whether you are signed in')
+  .action(whoami);
 
 deadrop
   .command('update')

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,9 +3,11 @@ import './scripts/bun-inject';
 import 'dotenv/config';
 import { deadrop } from 'core';
 import { checkNodeVersion, checkBunVersion } from 'lib/util';
+import { migrateLegacyCreds } from 'lib/auth/cache';
 
 checkBunVersion();
 checkNodeVersion();
+migrateLegacyCreds();
 
 deadrop.parse();
 

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -11,6 +11,16 @@ case "$(uname -s)" in
   *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
 esac
 
+if [ "$OS" = "linux" ] && command -v ldconfig >/dev/null 2>&1; then
+  if ! ldconfig -p | grep -q libsecret-1; then
+    echo "deadrop requires libsecret for secure credential storage."
+    echo "Install it with:"
+    echo "  Ubuntu/Debian: sudo apt-get install -y libsecret-1-0"
+    echo "  Fedora/RHEL:   sudo dnf install -y libsecret"
+    echo "  Arch:          sudo pacman -S libsecret"
+  fi
+fi
+
 case "$(uname -m)" in
   arm64|aarch64) ARCH="arm64" ;;
   x86_64)        ARCH="x64" ;;

--- a/cli/lib/auth/cache.ts
+++ b/cli/lib/auth/cache.ts
@@ -23,6 +23,17 @@ function isMissingEntry(err: unknown): boolean {
   return msg.includes('no matching entry') || msg.includes('no entry');
 }
 
+// Linux failures are almost always the missing libsecret shared lib;
+// macOS/Windows failures are almost always the user denying the
+// keychain/Credential Manager access prompt. Point at the fix for each,
+// since "install libsecret" is meaningless (and confusing) on a Mac.
+function keychainUnavailableMessage(): string {
+  if (process.platform === 'linux') {
+    return 'Secure credential storage is unavailable. Install libsecret (e.g. `sudo apt-get install -y libsecret-1-0`) and run `deadrop login` again.';
+  }
+  return 'Secure credential storage is unavailable. If your OS just prompted for keychain access, allow it and run `deadrop login` again.';
+}
+
 // Never throws: missing entry is silent, backend failure warns once
 export async function getToken(): Promise<string> {
   try {
@@ -53,9 +64,7 @@ export async function setSession(token: string): Promise<void> {
     const { Entry } = require('@napi-rs/keyring');
     new Entry(SERVICE, ACCOUNT).setPassword(token);
   } catch {
-    throw new Error(
-      'Secure credential storage is unavailable. On Linux, install libsecret (e.g. `sudo apt-get install -y libsecret-1-0`).',
-    );
+    throw new Error(keychainUnavailableMessage());
   }
 }
 

--- a/cli/lib/auth/cache.ts
+++ b/cli/lib/auth/cache.ts
@@ -1,53 +1,83 @@
-import { cosmiconfig } from 'cosmiconfig';
-import { existsSync } from 'fs';
-import { mkdir, writeFile } from 'fs/promises';
-import { STORAGE_DIR_NAME } from '@shared/lib/constants';
+import { existsSync, unlinkSync } from 'fs';
 import { cwd } from 'process';
-import { stringify } from 'yaml';
+import { STORAGE_DIR_NAME } from '@shared/lib/constants';
+import { logInfo } from 'lib/log';
 
-type AuthCache = {
-  token: string;
-  lastAuthenticated: number;
-};
+const SERVICE = 'deadrop-cli';
+const ACCOUNT = 'auth-token';
 
-const getAuthCachePath = () => {
-  const dirPath = `${cwd()}/${STORAGE_DIR_NAME}/creds`;
+let warnedKeychainError = false;
 
-  return dirPath;
-};
-
-export async function readAuthCache() {
-  const cachePath = getAuthCachePath();
-  const cacheExists = existsSync(cachePath);
-
-  if (!cacheExists) return null;
-
-  const { load } = cosmiconfig('deadrop');
-
-  const authCacheConfig = await load(getAuthCachePath());
-
-  return authCacheConfig!.config as AuthCache;
+// Warn once per process when the keychain backend is unreachable
+function warnKeychainOnce(): void {
+  if (warnedKeychainError) return;
+  warnedKeychainError = true;
+  logInfo(
+    'Could not reach your OS keychain; continuing unauthenticated. Run `deadrop login` once your keychain is available.',
+  );
 }
 
-export async function writeAuthCache(cache: AuthCache) {
-  const configString = stringify(cache);
-
-  const configDir = `${cwd()}/${STORAGE_DIR_NAME}`;
-
-  if (!existsSync(configDir)) await mkdir(configDir);
-
-  await writeFile(getAuthCachePath(), configString);
+// NoEntry (no stored credential) vs a real backend failure
+function isMissingEntry(err: unknown): boolean {
+  const msg = String((err as Error)?.message ?? '').toLowerCase();
+  return msg.includes('no matching entry') || msg.includes('no entry');
 }
 
-export async function getToken() {
-  const authCache = await readAuthCache();
-
-  return authCache?.token ?? '';
+// Never throws: missing entry is silent, backend failure warns once
+export async function getToken(): Promise<string> {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary') {
+      return (
+        (await Bun.secrets.get({ service: SERVICE, name: ACCOUNT })) ?? ''
+      );
+    }
+    const { Entry } = require('@napi-rs/keyring');
+    return new Entry(SERVICE, ACCOUNT).getPassword() ?? '';
+  } catch (err) {
+    if (!isMissingEntry(err)) warnKeychainOnce();
+    return '';
+  }
 }
 
-export async function setSession(token: string) {
-  await writeAuthCache({
-    token,
-    lastAuthenticated: Date.now(),
-  });
+// Login-only write: failure surfaces instead of faking a successful login
+export async function setSession(token: string): Promise<void> {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary') {
+      await Bun.secrets.set({
+        service: SERVICE,
+        name: ACCOUNT,
+        value: token,
+      });
+      return;
+    }
+    const { Entry } = require('@napi-rs/keyring');
+    new Entry(SERVICE, ACCOUNT).setPassword(token);
+  } catch {
+    throw new Error(
+      'Secure credential storage is unavailable. On Linux, install libsecret (e.g. `sudo apt-get install -y libsecret-1-0`).',
+    );
+  }
+}
+
+export async function clearSession(): Promise<void> {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary') {
+      await Bun.secrets.delete({ service: SERVICE, name: ACCOUNT });
+      return;
+    }
+    const { Entry } = require('@napi-rs/keyring');
+    new Entry(SERVICE, ACCOUNT).deletePassword();
+  } catch {
+    // already gone or backend unavailable
+  }
+}
+
+// Remove the legacy plaintext creds file from cwd, if present
+export function migrateLegacyCreds(): void {
+  const legacyPath = `${cwd()}/${STORAGE_DIR_NAME}/creds`;
+  if (!existsSync(legacyPath)) return;
+  unlinkSync(legacyPath);
+  logInfo(
+    'Removed legacy plaintext credential; credentials now use your OS keychain. Run `deadrop login` to sign in again.',
+  );
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@hono/node-server": "^1.13.2",
     "@inquirer/prompts": "^5.3.8",
+    "@napi-rs/keyring": "^1.3.0",
     "chalk": "^5.2.0",
     "change-case": "^5.4.4",
     "commander": "^9.4.1",

--- a/cli/scripts/esbuild.js
+++ b/cli/scripts/esbuild.js
@@ -26,9 +26,10 @@ if (missing.length) {
     outfile: 'dist/deadrop.js',
     platform: 'node',
     bundle: true,
+    minifySyntax: true,
     inject: ['./scripts/inject.js'],
     loader: { '.node': 'file' },
-    external: ['libsql', 'node-datachannel'],
+    external: ['libsql', 'node-datachannel', '@napi-rs/keyring'],
     plugins: [
       environmentPlugin({
         DEADROP_API_URL: process.env.DEADROP_API_URL,

--- a/cli/tests/unit/cache.spec.ts
+++ b/cli/tests/unit/cache.spec.ts
@@ -59,3 +59,55 @@ describe('getToken', () => {
     expect(await getToken()).toEqual('a-token');
   });
 });
+
+describe('setSession', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.DEADROP_INSTALL_METHOD;
+  });
+
+  const mockSetPasswordFailure = () => {
+    const setPassword = vi.fn().mockImplementation(() => {
+      throw new Error('access denied');
+    });
+    vi.spyOn(keyring, 'Entry').mockImplementation(
+      () => ({ setPassword }) as any,
+    );
+  };
+
+  it('points Linux users at libsecret', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+    mockSetPasswordFailure();
+    const { setSession } = await import('lib/auth/cache');
+
+    await expect(setSession('token')).rejects.toThrow(/libsecret/);
+  });
+
+  it('points macOS/Windows users at their keychain prompt, not libsecret', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+    mockSetPasswordFailure();
+    const { setSession } = await import('lib/auth/cache');
+
+    await expect(setSession('token')).rejects.toThrow(
+      /keychain access/,
+    );
+    await expect(setSession('token')).rejects.not.toThrow(/libsecret/);
+  });
+
+  it('writes the token when the backend succeeds', async () => {
+    const setPassword = vi.fn();
+    vi.spyOn(keyring, 'Entry').mockImplementation(
+      () => ({ setPassword }) as any,
+    );
+    const { setSession } = await import('lib/auth/cache');
+
+    await setSession('a-token');
+
+    expect(setPassword).toHaveBeenCalledWith('a-token');
+  });
+});

--- a/cli/tests/unit/cache.spec.ts
+++ b/cli/tests/unit/cache.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/log', () => ({
+  logInfo: vi.fn(),
+}));
+
+// cache.ts loads @napi-rs/keyring via an inline require() (required for
+// bundler DCE), which bypasses vi.mock's static import interception. Patch
+// the real, Node-cached module object instead so cache.ts's own require()
+// picks up the same mocked Entry.
+const keyring = require('@napi-rs/keyring');
+
+describe('getToken', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.DEADROP_INSTALL_METHOD;
+  });
+
+  it('returns an empty string with no warning when no credential is stored', async () => {
+    const getPassword = vi.fn().mockImplementation(() => {
+      throw new Error('No matching entry found in secure storage');
+    });
+    vi.spyOn(keyring, 'Entry').mockImplementation(
+      () => ({ getPassword }) as any,
+    );
+    const { getToken } = await import('lib/auth/cache');
+    const { logInfo } = await import('lib/log');
+
+    expect(await getToken()).toEqual('');
+    expect(logInfo).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty string and warns once across repeated calls on a backend failure', async () => {
+    const getPassword = vi.fn().mockImplementation(() => {
+      throw new Error('keychain daemon unreachable');
+    });
+    vi.spyOn(keyring, 'Entry').mockImplementation(
+      () => ({ getPassword }) as any,
+    );
+    const { getToken } = await import('lib/auth/cache');
+    const { logInfo } = await import('lib/log');
+
+    expect(await getToken()).toEqual('');
+    expect(await getToken()).toEqual('');
+    expect(logInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the stored token', async () => {
+    const getPassword = vi.fn().mockReturnValue('a-token');
+    vi.spyOn(keyring, 'Entry').mockImplementation(
+      () => ({ getPassword }) as any,
+    );
+    const { getToken } = await import('lib/auth/cache');
+
+    expect(await getToken()).toEqual('a-token');
+  });
+});

--- a/cli/tests/unit/login.spec.ts
+++ b/cli/tests/unit/login.spec.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/auth/clerk', () => ({
+  createClerkClient: vi.fn(),
+}));
+
+vi.mock('lib/auth/localhostServer', () => ({
+  createLocalAuthServer: vi.fn(),
+}));
+
+vi.mock('lib/log', () => ({
+  loader: { start: vi.fn(), stop: vi.fn(), text: '' },
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+vi.mock('open', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports already-signed-in and never opens the browser', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { createLocalAuthServer } = await import(
+      'lib/auth/localhostServer'
+    );
+    const { logInfo } = await import('lib/log');
+    const open = (await import('open')).default;
+    const login = (await import('actions/login')).default;
+
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: { user: { emailAddresses: ['nieky@example.com'] } },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await login();
+
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining('already signed in'),
+    );
+    expect(createLocalAuthServer).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+
+  it('completes sign-in when the browser hands back a valid ticket', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { createLocalAuthServer } = await import(
+      'lib/auth/localhostServer'
+    );
+    const { logInfo } = await import('lib/log');
+    const login = (await import('actions/login')).default;
+
+    const signInCreate = vi
+      .fn()
+      .mockResolvedValue({ status: 'complete' });
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: null,
+      client: { signIn: { create: signInCreate } },
+    } as any);
+    vi.mocked(createLocalAuthServer).mockResolvedValue({
+      listenForAuthRedirect: vi.fn().mockResolvedValue('a-ticket'),
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await login();
+
+    expect(signInCreate).toHaveBeenCalledWith({
+      strategy: 'ticket',
+      ticket: 'a-ticket',
+    });
+    expect(logInfo).toHaveBeenCalledWith('Successfully logged in!');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+
+  it('fails when the redirect never produces a token', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { createLocalAuthServer } = await import(
+      'lib/auth/localhostServer'
+    );
+    const { logError } = await import('lib/log');
+    const login = (await import('actions/login')).default;
+
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: null,
+      client: { signIn: { create: vi.fn() } },
+    } as any);
+    vi.mocked(createLocalAuthServer).mockResolvedValue({
+      listenForAuthRedirect: vi.fn().mockResolvedValue(null),
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await login();
+
+    expect(logError).toHaveBeenCalledWith(
+      'Authentication with provided token failed!',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('fails when clerk rejects the ticket', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { createLocalAuthServer } = await import(
+      'lib/auth/localhostServer'
+    );
+    const { logError } = await import('lib/log');
+    const login = (await import('actions/login')).default;
+
+    const signInCreate = vi
+      .fn()
+      .mockRejectedValue(new Error('This ticket is invalid.'));
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: null,
+      client: { signIn: { create: signInCreate } },
+    } as any);
+    vi.mocked(createLocalAuthServer).mockResolvedValue({
+      listenForAuthRedirect: vi.fn().mockResolvedValue('a-ticket'),
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await login();
+
+    expect(logError).toHaveBeenCalledWith(
+      'Authentication with provided token failed!',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+});

--- a/cli/tests/unit/logout.spec.ts
+++ b/cli/tests/unit/logout.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/auth/clerk', () => ({
+  createClerkClient: vi.fn(),
+}));
+
+vi.mock('lib/auth/cache', () => ({
+  clearSession: vi.fn(),
+}));
+
+vi.mock('lib/log', () => ({
+  logInfo: vi.fn(),
+}));
+
+describe('logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports not signed in and skips clearSession when there is no session', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { clearSession } = await import('lib/auth/cache');
+    const { logInfo } = await import('lib/log');
+    const logout = (await import('actions/logout')).default;
+
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: null,
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await logout();
+
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining("You're not signed in"),
+    );
+    expect(clearSession).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+
+  it('signs out of clerk, clears the stored session, and confirms', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { clearSession } = await import('lib/auth/cache');
+    const { logInfo } = await import('lib/log');
+    const logout = (await import('actions/logout')).default;
+
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: { id: 'sess_123' },
+      signOut,
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await logout();
+
+    expect(signOut).toHaveBeenCalled();
+    expect(clearSession).toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith('Successfully signed out!');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+});

--- a/cli/tests/unit/whoami.spec.ts
+++ b/cli/tests/unit/whoami.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/auth/clerk', () => ({
+  createClerkClient: vi.fn(),
+}));
+
+vi.mock('lib/log', () => ({
+  logInfo: vi.fn(),
+}));
+
+describe('whoami', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports signed-out when there is no session', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { logInfo } = await import('lib/log');
+    const whoami = (await import('actions/whoami')).default;
+
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: null,
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await whoami();
+
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining("You're not signed in"),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+
+  it('prints the signed-in email when there is a session', async () => {
+    const { createClerkClient } = await import('lib/auth/clerk');
+    const { logInfo } = await import('lib/log');
+    const whoami = (await import('actions/whoami')).default;
+
+    vi.mocked(createClerkClient).mockResolvedValue({
+      session: {
+        user: { emailAddresses: ['nieky@example.com'] },
+      },
+    } as any);
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await whoami();
+
+    expect(logInfo).toHaveBeenCalledWith(
+      'Signed in as nieky@example.com',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^5.3.8
         version: 5.5.0
+      '@napi-rs/keyring':
+        specifier: ^1.3.0
+        version: 1.3.0
       chalk:
         specifier: ^5.2.0
         version: 5.6.2
@@ -2549,6 +2552,82 @@ packages:
 
   '@msgpack/msgpack@2.8.0':
     resolution: {integrity: sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -11781,6 +11860,57 @@ snapshots:
       react: 18.3.1
 
   '@msgpack/msgpack@2.8.0': {}
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:

--- a/scripts/changeset-publish.js
+++ b/scripts/changeset-publish.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
-// Changesets uses the `name` field for npm version checks and tag creation.
-// Since our workspace is named "cli" but publishes as "deadrop", we patch the
-// name before changeset publish runs, then restore it after.
+// Patches the name to "deadrop" for publish and leaves it patched — changesets/action reads this file again after we exit to resolve publishedPackages, and release.yml restores it via `git checkout` once that's done.
 
 const fs = require('fs');
 const { execSync } = require('child_process');
@@ -13,9 +11,4 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 pkg.name = 'deadrop';
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 
-try {
-    execSync('changeset publish', { stdio: 'inherit' });
-} finally {
-    pkg.name = 'cli';
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-}
+execSync('changeset publish', { stdio: 'inherit' });

--- a/specs/cli-bun-migration.md
+++ b/specs/cli-bun-migration.md
@@ -314,7 +314,7 @@ jobs:
           - os: windows-latest  target: win32-x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: pnpm install --frozen-lockfile
       - run: pnpm cli:build
@@ -323,7 +323,7 @@ jobs:
           # ... other env vars
       - name: Rename binary for release
         run: mv cli/dist/deadrop cli/dist/deadrop-${{ matrix.target }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: deadrop-${{ matrix.target }}
           path: cli/dist/deadrop-${{ matrix.target }}
@@ -332,7 +332,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
       - uses: softprops/action-gh-release@v2
         with:
           files: deadrop-*/deadrop-*

--- a/specs/keytar-migration.md
+++ b/specs/keytar-migration.md
@@ -1,0 +1,316 @@
+# Keychain Migration Spec
+
+## Current State
+
+`cli/lib/auth/cache.ts` stores a Clerk JWT + timestamp as a YAML file at `<cwd>/.deadrop/creds` using cosmiconfig. The token sits in plaintext on disk in whatever directory the user runs `deadrop` from.
+
+Problems:
+- Plaintext credential on disk
+- Tied to `cwd()` — different directories = different auth sessions
+- No OS-level access control
+
+## Proposed State
+
+Two credential backends selected at build time:
+
+- **Node.js (JS bundle via npm):** `@napi-rs/keyring` — native OS keychain bindings (Keychain on macOS, libsecret/Secret Service on Linux, Credential Manager on Windows). A maintained, prebuilt-binary alternative to the archived `keytar`.
+- **Bun (compiled binary):** Bun's built-in `Bun.secrets` API — same OS credential stores.
+
+`cache.ts` exports the same interface (`getToken`, `setSession`, `clearSession`) regardless of backend.
+
+### Backend selection: `DEADROP_INSTALL_METHOD`, not `typeof Bun`
+
+Branch on the build-time constant `process.env.DEADROP_INSTALL_METHOD`. It is **already** baked by both pipelines:
+
+- `cli/scripts/esbuild.js` → `environmentPlugin({ ..., DEADROP_INSTALL_METHOD: 'npm' })`
+- `cli/scripts/bun-build.ts` → `envVars['process.env.DEADROP_INSTALL_METHOD'] = JSON.stringify('binary')`
+
+Because each pipeline replaces `process.env.DEADROP_INSTALL_METHOD` with a string literal, `process.env.DEADROP_INSTALL_METHOD === 'binary'` folds to a constant at build time and the unused branch is dead-code-eliminated:
+- esbuild (npm bundle): folds to `false` → the `Bun.secrets` branch is dropped.
+- Bun (binary): folds to `true` → the `@napi-rs/keyring` branch (and its `require`) is dropped, so the native `.node` addon is never pulled into the single-file binary.
+
+Do **not** branch on `typeof Bun`: it is a runtime check the bundlers cannot fold, so Bun would try to bundle the `@napi-rs/keyring` native addon into the binary and fail. bun-build.ts already documents this exact hazard in a comment.
+
+The keyring dependency is loaded via an inline `require('@napi-rs/keyring')` *inside* the non-binary branch (never a top-level `import`), so Bun reliably drops it once that branch is eliminated.
+
+For the same reason, write the comparison inline in each function — do **not** extract it into a helper like `const isBinary = () => ...`. Define-substitution only folds the literal comparison at the site where it appears; neither bundler inlines function calls, so a helper makes the branch opaque, DCE stops working, and the Bun compile fails trying to bundle the native addon.
+
+## File-by-File Implementation
+
+### 1. `cli/lib/auth/cache.ts` — full rewrite
+
+Replace the entire file with:
+
+```ts
+import { logInfo } from '../log';
+
+const SERVICE = 'deadrop-cli';
+const ACCOUNT = 'auth-token';
+
+let warnedKeychainError = false;
+
+// Warn once per process when the keychain backend is unreachable
+function warnKeychainOnce(): void {
+  if (warnedKeychainError) return;
+  warnedKeychainError = true;
+  logInfo(
+    'Could not reach your OS keychain; continuing unauthenticated. Run `deadrop login` once your keychain is available.',
+  );
+}
+
+// NoEntry (no stored credential) vs a real backend failure
+function isMissingEntry(err: unknown): boolean {
+  const msg = String((err as Error)?.message ?? '').toLowerCase();
+  return msg.includes('no matching entry') || msg.includes('no entry');
+}
+
+// Linux failures are almost always the missing libsecret shared lib;
+// macOS/Windows failures are almost always the user denying the
+// keychain/Credential Manager access prompt. Point at the fix for each,
+// since "install libsecret" is meaningless (and confusing) on a Mac.
+function keychainUnavailableMessage(): string {
+  if (process.platform === 'linux') {
+    return 'Secure credential storage is unavailable. Install libsecret (e.g. `sudo apt-get install -y libsecret-1-0`) and run `deadrop login` again.';
+  }
+  return 'Secure credential storage is unavailable. If your OS just prompted for keychain access, allow it and run `deadrop login` again.';
+}
+
+// Never throws: missing entry is silent, backend failure warns once
+export async function getToken(): Promise<string> {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary') {
+      return (
+        (await Bun.secrets.get({ service: SERVICE, name: ACCOUNT })) ?? ''
+      );
+    }
+    const { Entry } = require('@napi-rs/keyring');
+    return new Entry(SERVICE, ACCOUNT).getPassword() ?? '';
+  } catch (err) {
+    if (!isMissingEntry(err)) warnKeychainOnce();
+    return '';
+  }
+}
+
+// Login-only write: failure surfaces instead of faking a successful login
+export async function setSession(token: string): Promise<void> {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary') {
+      await Bun.secrets.set({
+        service: SERVICE,
+        name: ACCOUNT,
+        value: token,
+      });
+      return;
+    }
+    const { Entry } = require('@napi-rs/keyring');
+    new Entry(SERVICE, ACCOUNT).setPassword(token);
+  } catch {
+    throw new Error(keychainUnavailableMessage());
+  }
+}
+
+export async function clearSession(): Promise<void> {
+  try {
+    if (process.env.DEADROP_INSTALL_METHOD === 'binary') {
+      await Bun.secrets.delete({ service: SERVICE, name: ACCOUNT });
+      return;
+    }
+    const { Entry } = require('@napi-rs/keyring');
+    new Entry(SERVICE, ACCOUNT).deletePassword();
+  } catch {
+    // already gone or backend unavailable
+  }
+}
+```
+
+API details to get right:
+- `Bun.secrets.set` takes a single object with a `value` field: `set({ service, name, value })`. It is **not** a two-arg `set(options, token)` call.
+- `Bun.secrets.get` / `.delete` take `{ service, name }`. `.get` returns `string | null`.
+- `@napi-rs/keyring` uses the sync `Entry` class (constructor `new Entry(service, username)`, methods `getPassword()` / `setPassword(pw)` / `deletePassword()`). `getPassword()` returns `string | undefined` and throws `NoEntry` when missing — the `try/catch` handles both.
+- `isMissingEntry` matches the NoEntry error **message string**, which is version-sensitive: verify the actual message thrown by the installed `@napi-rs/keyring` version (a quick script or the unit test in Verification #7) and widen the match if it differs.
+- The removed exports `readAuthCache` / `writeAuthCache` had no external consumers (only `getToken`/`setSession` are imported, by `clerk.ts`) — safe to drop.
+- The `Bun` global typechecks because `@types/bun` is already a devDep. No new type dependency.
+
+### 2. `cli/lib/auth/cache.ts` — add legacy migration helper
+
+Append to the same file (the one-time notify-and-delete for the old plaintext creds). `logInfo` is already imported by the rewrite above; add only the `fs` / `process` / constants imports:
+
+```ts
+import { existsSync, unlinkSync } from 'fs';
+import { cwd } from 'process';
+import { STORAGE_DIR_NAME } from '@shared/lib/constants';
+
+// Remove the legacy plaintext creds file from cwd, if present
+export function migrateLegacyCreds(): void {
+  const legacyPath = `${cwd()}/${STORAGE_DIR_NAME}/creds`;
+  if (!existsSync(legacyPath)) return;
+  unlinkSync(legacyPath);
+  logInfo(
+    'Removed legacy plaintext credential; credentials now use your OS keychain. Run `deadrop login` to sign in again.',
+  );
+}
+```
+
+Confirm the `logInfo` import path resolves the same way `logout.ts` imports it (`lib/log`); adjust the relative specifier if needed so it matches the existing convention in `cli/lib/`.
+
+### 3. `cli/index.ts` — call the migration once at startup
+
+Add the import and invoke it after the version checks, before `deadrop.parse()`:
+
+```ts
+import { migrateLegacyCreds } from 'lib/auth/cache';
+// ...
+checkBunVersion();
+checkNodeVersion();
+migrateLegacyCreds();
+
+deadrop.parse();
+```
+
+### 4. `cli/actions/logout.ts` — use `clearSession()`
+
+Replace the file-deletion block. The current file imports `existsSync`, `unlink`, `STORAGE_DIR_NAME`, and `cwd` solely to delete the creds file; remove all four. New version:
+
+```ts
+import { createClerkClient } from 'lib/auth/clerk';
+import { clearSession } from 'lib/auth/cache';
+import { logInfo } from 'lib/log';
+
+export default async function logout() {
+  const clerkClient = await createClerkClient();
+
+  if (!clerkClient.session) {
+    logInfo(
+      `You're not signed in right now!\nRun \`deadrop login\` to get started.`,
+    );
+
+    return process.exit(0);
+  }
+
+  await clerkClient.signOut();
+
+  await clearSession();
+
+  logInfo('Successfully signed out!');
+
+  process.exit(0);
+}
+```
+
+### 5. `cli/scripts/esbuild.js` — externalize the native addon
+
+`@napi-rs/keyring` is a native `.node` addon and cannot be bundled. Add it to the existing `external` array:
+
+```js
+external: ['libsql', 'node-datachannel', '@napi-rs/keyring'],
+```
+
+No change to `bun-build.ts` — the keyring branch is DCE'd out of the binary (see backend-selection section). If Bun ever fails to eliminate it, the symptom is a compile error resolving `@napi-rs/keyring`; the fix is to confirm the `DEADROP_INSTALL_METHOD` define is present in `bun-build.ts`, not to add a Bun external (a compiled single-file binary cannot resolve an external native addon at runtime).
+
+**Also add `minifySyntax: true` to the `build()` call.** The `DEADROP_INSTALL_METHOD` define alone does not eliminate the dead `Bun.secrets` branch from the npm bundle — esbuild only performs dead-branch elimination on constant-folded conditions when `minifySyntax`/`minify` is set, and `esbuild.js` previously built unminified. Without it the `Bun.secrets` calls survive as inert text in `dist/deadrop.js` (harmless at runtime since the guard is always `false` there, but it fails the grep in Verification #2). `minifySyntax: true` drops dead branches without mangling identifiers or whitespace, so the bundle stays readable. `bun-build.ts` already sets `minify: true` and doesn't need this change.
+
+### 6. `cli/package.json` — deps
+
+Add to `dependencies`:
+
+```json
+"@napi-rs/keyring": "^1.3.0"
+```
+
+(Pin to the current latest — `1.3.0` as of this migration, not the `1.1.7` in earlier drafts of this spec; check `npm view @napi-rs/keyring version` before implementing, since it may have moved again. `@napi-rs/keyring` ships its platform binaries as its own `optionalDependencies`, so pnpm resolves the correct `.node` automatically — no manual per-platform entries needed, unlike `libsql`.)
+
+Do **not** add any type dep — `@types/bun` is already present in `devDependencies`.
+
+### 7. `cli/actions/whoami.ts` — new command
+
+A read-only check of the current sign-in state, so users have a way to confirm credentials actually made it into the OS keychain (or that a stored token is still valid) without triggering a full `login`/`logout` cycle. Mirrors `logout.ts`'s shape:
+
+```ts
+import { createClerkClient } from 'lib/auth/clerk';
+import { logInfo } from 'lib/log';
+
+export default async function whoami() {
+  const clerkClient = await createClerkClient();
+
+  if (!clerkClient.session) {
+    logInfo(
+      `You're not signed in.\nRun \`deadrop login\` to get started.`,
+    );
+
+    return process.exit(0);
+  }
+
+  logInfo(
+    `Signed in as ${clerkClient.session.user.emailAddresses[0]}`,
+  );
+
+  process.exit(0);
+}
+```
+
+Wire it into `cli/core.ts` next to `login`/`logout`:
+
+```ts
+import whoami from 'actions/whoami';
+// ...
+deadrop
+  .command('whoami')
+  .description('check whether you are signed in')
+  .action(whoami);
+```
+
+`createClerkClient()` resolving `clerkClient.session` already round-trips through `getToken()` (keychain read) and Clerk's own session validation, so `whoami` doubles as a smoke test for the keychain backend — a bare `security find-generic-password -s deadrop-cli -a auth-token` (macOS) or `secret-tool lookup service deadrop-cli account auth-token` (Linux) only proves *something* is stored, not that it's still a valid session.
+
+### Out of scope — do NOT remove `cosmiconfig` or `yaml`
+
+Both remain load-bearing for the deadrop config file in `cli/lib/config.ts`:
+- `cosmiconfig('deadrop')` powers `loadConfig()` (config discovery).
+- `yaml`'s `parse` / `stringify` power `loadConfigFromPath()` and `saveConfig()`.
+
+Only `cache.ts` stops importing them; both packages stay in `dependencies`.
+
+## Linux: libsecret System Dependency
+
+Both `Bun.secrets` and `@napi-rs/keyring` use `libsecret` (GNOME Keyring / KWallet) on Linux. It's a system shared library loaded at runtime via `dlopen` — it cannot be bundled into either the Bun binary or the JS bundle. macOS (Keychain) and Windows (Credential Manager) have no equivalent runtime dependency.
+
+**What `install.sh` should do on Linux** (add after Linux detection):
+```bash
+if ! ldconfig -p | grep -q libsecret-1; then
+  echo "deadrop requires libsecret for secure credential storage."
+  echo "Install it with:"
+  echo "  Ubuntu/Debian: sudo apt-get install -y libsecret-1-0"
+  echo "  Fedora/RHEL:   sudo dnf install -y libsecret"
+  echo "  Arch:          sudo pacman -S libsecret"
+fi
+```
+
+Runtime package is `libsecret-1-0` (not `-dev`); `@napi-rs/keyring` ships prebuilt `.node` files, so only the shared lib is needed. For CI / Docker images: `apt-get install -y libsecret-1-0`.
+
+## macOS/Windows: repeated access prompts on unsigned/dev builds
+
+macOS ties a Keychain item's ACL to the specific requesting binary. Ad-hoc/dev builds (esbuild output run via plain `node`, or a locally `bun compile`d binary) get a different signature on every rebuild, so the OS treats each rebuild as a new, untrusted app and re-prompts for access — this is expected during development, not a bug. A `deadrop login` run can also trigger two separate prompts in the same process (one for the `getToken` read, one for the `setSession` write), since macOS can gate reads and writes on an item separately.
+
+For a real release this goes away once the Bun binary is codesigned and notarized with a stable Apple Developer ID: "Always Allow" then persists across runs of that specific signed artifact. Signing/notarizing the release binary is tracked as a follow-up (not part of this migration) — needs an Apple Developer account and a CI signing step.
+
+## Fallback Behavior (read vs write asymmetry)
+
+- **Reads (`getToken`)** never throw — they return `''` (anonymous). But the three cases are distinguished: no stored credential is silent (normal signed-out), whereas an unreachable/broken backend warns **once per process** ("Could not reach your OS keychain; continuing unauthenticated…") so the user isn't left wondering why auth silently stopped. This is the hot path (every API call via `clerk.ts` `onBeforeRequest`), hence the once-per-process guard.
+- **Writes (`setSession`)** throw a platform-appropriate error — the one point where the user can act on it. On Linux this names libsecret (the likely cause); on macOS/Windows it points at the OS keychain/Credential Manager access prompt instead, since "install libsecret" is meaningless there and the actual cause on those platforms is almost always the user denying (or not being asked about) that prompt. Falling back to plaintext storage on denial is explicitly out of scope — it would undo the entire point of this migration, so a write failure fails the login instead of silently degrading to disk.
+
+## Verification
+
+Run all of these; each must pass:
+
+1. **Typecheck:** `pnpm -F cli exec tsc --noEmit` (or the repo's cli typecheck script) — confirms the `Bun` global and `@napi-rs/keyring` types resolve.
+2. **npm bundle build:** `pnpm cli:build` — must succeed with `@napi-rs/keyring` externalized; grep `dist/deadrop.js` to confirm no `Bun.secrets` string survives (branch DCE'd — requires `minifySyntax: true` per step 5 above, not just the `define`).
+3. **Bun binary build:** `pnpm -F cli compile` — must succeed; the compile must not attempt to resolve `@napi-rs/keyring` (branch DCE'd).
+4. **Runtime, Node path (npm):** `deadrop login` then `deadrop whoami` prints the signed-in email; `deadrop grab`/authenticated call succeeds; token is in the OS keychain, not on disk (`security find-generic-password -s deadrop-cli -a auth-token` on macOS). `deadrop logout` clears it and `deadrop whoami` reports signed-out again.
+5. **Runtime, missing backend:** with libsecret unavailable (or simulated by mocking `Entry` to throw a non-NoEntry error), an authenticated command still runs anonymously (no crash) and prints the "Could not reach your OS keychain" warning exactly once even across multiple reads in one process; `deadrop login` fails with the libsecret message. Separately confirm a genuinely signed-out run (no credential stored) prints **no** such warning.
+6. **Migration:** create a stub `./.deadrop/creds` file, run any `deadrop` command → file is deleted and the re-auth notice prints once; a second run prints nothing.
+7. **Unit tests:** `pnpm vitest run --project cli` stays green; cover all three `getToken` outcomes: (a) `getPassword` throws a NoEntry-message error → returns `''`, no warn; (b) `getPassword` throws a non-NoEntry error → returns `''`, warns exactly once across repeated calls; (c) `getPassword` returns a token → returns it. Reset the module (or the `warnedKeychainError` flag) between cases so the once-per-process guard doesn't leak across tests.
+
+   **Mocking gotcha:** `cache.ts` loads `@napi-rs/keyring` via an inline `require()` inside each function (required for bundler DCE — see the backend-selection section), which `vi.mock('@napi-rs/keyring', ...)` does **not** intercept; it only patches statically-imported specifiers, and a probe test confirms the real native module gets hit instead of the mock. Mock it by `require()`-ing the real module once at the top of the test file and `vi.spyOn(keyring, 'Entry').mockImplementation(...)` — Node's module cache means `cache.ts`'s own `require()` calls resolve to the same patched object.
+
+## Post-Merge
+
+Update the memory pointer for this spec: backend is `@napi-rs/keyring` (Node) + `Bun.secrets` (binary), not `keytar`; `deadrop whoami` is the way to check sign-in state / verify the keychain write worked.

--- a/web/atoms/Code.tsx
+++ b/web/atoms/Code.tsx
@@ -8,11 +8,11 @@ export const BlockCode = ({ children }: PropsWithChildren) => {
     <Code
       block
       style={{
-        fontSize: theme.fontSizes.md,
-        padding: theme.spacing.sm,
+        fontSize: theme.spacing.md,
+        padding: theme.spacing.xs,
         marginTop: theme.spacing.xs,
         marginBottom: theme.spacing.md,
-        marginLeft: theme.spacing.xs,
+        marginLeft: '8px',
         marginRight: theme.spacing.xs,
         borderLeft: `2px solid ${theme.colors.blue[9]}a8`,
       }}
@@ -35,7 +35,7 @@ export const InlineCode = ({
     <Code
       block={false}
       style={{
-        fontSize: size && theme.fontSizes[size],
+        fontSize: size ? theme.fontSizes[size] : '15px',
         padding: '2px 6px',
       }}
     >

--- a/web/mdx-components.tsx
+++ b/web/mdx-components.tsx
@@ -67,7 +67,7 @@ export function useMDXComponents(
     ),
     code: ({ children }) =>
       typeof children === 'string' && !children.includes('\n') ? (
-        <InlineCode size={'md'}>{children}</InlineCode>
+        <InlineCode>{children}</InlineCode>
       ) : (
         <BlockCode>{children}</BlockCode>
       ),

--- a/web/molecules/sections/SectionTitle.module.css
+++ b/web/molecules/sections/SectionTitle.module.css
@@ -1,3 +1,30 @@
 .title {
   margin-bottom: calc(var(--mantine-spacing-xl) * 1.5);
 }
+
+.docsTitle {
+  padding-top: var(--mantine-spacing-xl);
+  padding-bottom: var(--mantine-spacing-sm);
+  border-bottom: 1px solid
+    light-dark(
+      var(--mantine-color-gray-2),
+      var(--mantine-color-dark-4)
+    );
+  margin-bottom: var(--mantine-spacing-sm);
+}
+
+.linkIcon {
+  display: none;
+  padding: 0;
+  margin: 0;
+  height: unset;
+}
+
+.docsTitle:hover {
+  color: var(--mantine-color-blue-4);
+  cursor: pointer;
+
+  .linkIcon {
+    display: inline-block;
+  }
+}

--- a/web/molecules/sections/SectionTitle.tsx
+++ b/web/molecules/sections/SectionTitle.tsx
@@ -1,12 +1,35 @@
-import { Title } from '@mantine/core';
+import { Button, Title } from '@mantine/core';
 
 import classes from './SectionTitle.module.css';
+import { IconLink } from '@tabler/icons-react';
 
-export function SectionTitle({ id, label }: { id: string; label: string }) {
+export function SectionTitle({
+  id,
+  label,
+}: {
+  id: string;
+  label: string;
+}) {
+  return (
+    <Title id={id} ta={'center'} className={classes.title}>
+      {label}
+    </Title>
+  );
+}
 
-    return (
-        <Title id={id} ta={'center'} className={classes.title}>
-            {label}
-        </Title>
-    );
+export function DocsSectionTitle({
+  id,
+  label,
+}: {
+  id: string;
+  label: string;
+}) {
+  return (
+    <Title order={2} id={id} className={classes.docsTitle}>
+      {label}{' '}
+      <Button className={classes.linkIcon} variant={'transparent'}>
+        <IconLink />
+      </Button>
+    </Title>
+  );
 }

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -1,3 +1,4 @@
+import { BlockCode } from 'atoms/Code';
 import { INSTALL_COMMAND } from 'molecules/HeroBanner';
 
 # FAQs
@@ -18,9 +19,7 @@ Raw text strings, JSON payloads, and most plain-text configuration files (`.env`
 
 Run the one-line installer:
 
-```
-{INSTALL_COMMAND}
-```
+<BlockCode>{INSTALL_COMMAND}</BlockCode>
 
 The script downloads the appropriate binary for your platform and places it in your home directory. You can inspect it at `deadrop.io/install.sh` before running. The CLI is also available on npm as `deadrop` if you'd rather install it through your package manager.
 

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -1,5 +1,6 @@
 import { BlockCode } from 'atoms/Code';
 import { INSTALL_COMMAND } from 'molecules/HeroBanner';
+import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 
 # FAQs
 

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -5,7 +5,10 @@ import { INSTALL_COMMAND } from 'molecules/HeroBanner';
 
 Common questions about how deadrop works, what's stored, and how to use it.
 
-## 🚀 Getting started
+<DocsSectionTitle
+  id={'getting-started'}
+  label={'🚀 Getting started'}
+/>
 
 ### Do I need an account to use deadrop?
 
@@ -23,7 +26,10 @@ Run the one-line installer:
 
 The script downloads the appropriate binary for your platform and places it in your home directory. You can inspect it at `deadrop.io/install.sh` before running. The CLI is also available on npm as `deadrop` if you'd rather install it through your package manager.
 
-## 🔐 Security & cryptography
+<DocsSectionTitle
+  id={'security-and-cryptography'}
+  label={'🔐 Security & cryptography'}
+/>
 
 ### What cryptographic standards are leveraged to secure the handoff?
 
@@ -49,7 +55,10 @@ The script is hosted at `deadrop.io/install.sh` and is served over HTTPS. It dow
 curl -fsSL deadrop.io/install.sh
 ```
 
-## ⏱️ Drop lifecycle
+<DocsSectionTitle
+  id={'drop-lifecycle'}
+  label={'⏱️ Drop lifecycle'}
+/>
 
 ### How long does a drop session stay active?
 
@@ -67,7 +76,10 @@ One. Each drop session is a 1:1 handoff between dropper and grabber. Multi-recip
 
 You can start a new drop for each recipient. Each gets a unique drop ID and fresh keys. We deliberately don't reuse drop sessions so that compromising one handoff doesn't expose others.
 
-## 💻 Surfaces
+<DocsSectionTitle
+  id={'surfaces'}
+  label={'💻 Surfaces'}
+/>
 
 ### Is this service only available as a web application?
 
@@ -83,7 +95,10 @@ All three implement the same cryptographic protocol and can interoperate. For ex
 
 The web app is the easiest entry point and requires zero setup. The CLI is best for scripting, automation, dropping files from your terminal, and injecting vault secrets into CI/CD jobs (`deadrop inject`). It also unlocks CI/CD service tokens on paid plans. The VS Code extension brings drop, grab, and vault access into your editor without context-switching.
 
-## 🗄️ Vaults
+<DocsSectionTitle
+  id={'vaults'}
+  label={'🗄️ Vaults'}
+/>
 
 ### What is a vault?
 
@@ -93,7 +108,10 @@ A vault is a collection of secrets organised by environment (e.g. `production`, 
 
 Local vaults are stored as encrypted SQLite databases on the device you created them on. Cloud-synced vaults additionally back up the encrypted store to our managed Turso database so you can access the same secrets from multiple devices. In both cases, the contents are encrypted client-side, so we cannot read them.
 
-## 💳 Plans & pricing
+<DocsSectionTitle
+  id={'plans-and-pricing'}
+  label={'💳 Plans & pricing'}
+/>
 
 ### What features require a paid plan?
 

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -91,9 +91,10 @@ Authentication is only required for cloud-synced vaults and CI/CD service tokens
 ```
 deadrop login    # opens a browser to sign in via Clerk
 deadrop logout
+deadrop whoami   # check whether you're signed in
 ```
 
-Tokens are cached locally and refreshed automatically. The migration to OS keychain storage (macOS Keychain, Linux Secret Service, Windows Credential Vault) is in progress.
+Tokens are stored in your OS keychain (macOS Keychain, Linux Secret Service via libsecret, Windows Credential Vault) and refreshed automatically — never written to disk in plaintext.
 
 <DocsSectionTitle
   id={'commands'}

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -1,4 +1,4 @@
-import { InlineCode, BlockCode } from 'atoms/Code';
+import { BlockCode } from 'atoms/Code';
 import { INSTALL_COMMAND } from 'molecules/HeroBanner';
 
 # ⌨️ deadrop CLI
@@ -11,15 +11,9 @@ The CLI gives you everything the web app does (dropping and grabbing) plus local
 
 Downloads the prebuilt binary for your platform into your home directory. No Node.js required.
 
-```
-{INSTALL_COMMAND}
-```
+<BlockCode>{INSTALL_COMMAND}</BlockCode>
 
-You can fetch the script without executing it to read it first:
-
-```
-curl -fsSL deadrop.io/install.sh
-```
+If you are interested in the logic of the script, you can view it at `deadrop.io/install.sh`. It handles installing the appropriate binary for your platform and places it in your home directory for you.
 
 ### Via npm
 

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -1,3 +1,4 @@
+import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 import { BlockCode } from 'atoms/Code';
 import { INSTALL_COMMAND } from 'molecules/HeroBanner';
 
@@ -5,7 +6,10 @@ import { INSTALL_COMMAND } from 'molecules/HeroBanner';
 
 The CLI gives you everything the web app does (dropping and grabbing) plus local and cloud-synced vaults for secret storage, a `.env` sync workflow, and `inject` for running scripts and CI/CD jobs with vault secrets in their environment, no file on disk.
 
-## 📦 Installation
+<DocsSectionTitle
+  id={'installation'}
+  label={'📦 Installation'}
+/>
 
 ### One-line installer (recommended)
 
@@ -33,7 +37,10 @@ npx deadrop [command]
 
 For the npm install path: Node.js 20 or newer. The install.sh binary has no runtime dependencies.
 
-## 🚀 Quick start
+<DocsSectionTitle
+  id={'quick-start'}
+  label={'🚀 Quick start'}
+/>
 
 Share a secret in one terminal:
 
@@ -49,7 +56,10 @@ $ deadrop grab <drop_id>
 
 That's it. The two sessions complete a peer-to-peer handoff, the secret prints in the grabber's terminal, and both sessions exit.
 
-## ⚙️ Configuration
+<DocsSectionTitle
+  id={'configuration'}
+  label={'⚙️ Configuration'}
+/>
 
 Run the setup wizard once after install:
 
@@ -71,7 +81,10 @@ vaults:
 
 The `key` is the encryption key for the local SQLite vault file. Treat it like any other secret. Never commit your `.deadrop/` directory.
 
-## 🔐 Authentication
+<DocsSectionTitle
+  id={'authentication'}
+  label={'🔐 Authentication'}
+/>
 
 Authentication is only required for cloud-synced vaults and CI/CD service tokens. Drop and grab work without it.
 
@@ -82,7 +95,10 @@ deadrop logout
 
 Tokens are cached locally and refreshed automatically. The migration to OS keychain storage (macOS Keychain, Linux Secret Service, Windows Credential Vault) is in progress.
 
-## 📤 Commands
+<DocsSectionTitle
+  id={'commands'}
+  label={'📤 Commands'}
+/>
 
 ### `drop`
 
@@ -92,11 +108,11 @@ Share a secret with a single recipient over an end-to-end encrypted P2P connecti
 deadrop drop [options] [input]
 ```
 
-| Argument | Description |
-|---|---|
-| `[input]` | The secret to drop. If omitted, you'll be prompted. |
-| `-i, --input <value>` | Pass the secret as a flag instead of a positional argument. |
-| `-f, --file` | Treat the input as a file path and drop the file's contents. |
+| Argument              | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `[input]`             | The secret to drop. If omitted, you'll be prompted.          |
+| `-i, --input <value>` | Pass the secret as a flag instead of a positional argument.  |
+| `-f, --file`          | Treat the input as a file path and drop the file's contents. |
 
 **Examples:**
 
@@ -179,13 +195,13 @@ Run a command with a vault's secrets injected directly into its environment. Sec
 deadrop inject [options] -- <command...>
 ```
 
-| Option | Description |
-|---|---|
-| `-v, --vault <name>` | Vault to inject (default: the active vault). |
-| `-e, --environment <env>` | Environment to inject (default: the active vault's environment). |
-| `-c, --config <path>` | Load an explicit config file (JSON or YAML) instead of the auto-discovered config, for CI. |
-| `--no-override` | Let pre-existing environment variables win over vault values (default: vault values win). |
-| `--verbose` | Log the names of injected variables. Values are never logged. |
+| Option                    | Description                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `-v, --vault <name>`      | Vault to inject (default: the active vault).                                               |
+| `-e, --environment <env>` | Environment to inject (default: the active vault's environment).                           |
+| `-c, --config <path>`     | Load an explicit config file (JSON or YAML) instead of the auto-discovered config, for CI. |
+| `--no-override`           | Let pre-existing environment variables win over vault values (default: vault values win).  |
+| `--verbose`               | Log the names of injected variables. Values are never logged.                              |
 
 The `--` separator is required. Everything after it is passed straight through to your command, so its own flags are safe:
 
@@ -218,7 +234,10 @@ Remove a secret by name. Omit the name to pick interactively.
 deadrop secret remove API_KEY
 ```
 
-## 💡 Patterns
+<DocsSectionTitle
+  id={'patterns'}
+  label={'💡 Patterns'}
+/>
 
 **Drop a file's contents safely.** Avoid copy-paste accidents by dropping the file directly:
 
@@ -244,7 +263,10 @@ DB_URL=$(deadrop grab <drop_id>) ./deploy.sh
 deadrop inject --config ./deadrop-ci.json -- pnpm build
 ```
 
-## 🔗 Related
+<DocsSectionTitle
+  id={'related'}
+  label={'🔗 Related'}
+/>
 
 - [VS Code extension](/docs/features/vscode) for the same drop, grab, and vault flows inside your editor
 - [FAQs](/docs/faqs) for answers about security, accounts, and plans

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -1,3 +1,5 @@
+import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
+
 # 🚧 Features & Roadmap
 
 The goal of deadrop is to provide platform and device agnostic secret sharing in a streamlined and easy-to-use fashion. This page tracks what's shipped, what's in experimental rollout, and what's coming next.
@@ -11,7 +13,10 @@ Status key:
 
 For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/features/vscode) docs.
 
-## ✅ Shipped
+<DocsSectionTitle
+  id={'shipped'}
+  label={'✅ Shipped'}
+/>
 
 ### Sharing & handoff
 
@@ -36,7 +41,10 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 - **`deadrop inject`**: run a command with a vault's secrets injected into its environment, no file on disk. See the [CLI docs](/docs/features/cli) for usage.
 
-## 🧪 Experimental
+<DocsSectionTitle
+  id={'experimental'}
+  label={'🧪 Experimental'}
+/>
 
 ### Editor integration
 
@@ -55,13 +63,19 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 - **`deadrop login` / `logout`**: Clerk-backed CLI auth flow. Token cache currently lives on disk. [#25](https://github.com/dallen4/deadrop/issues/25)
 
-## 🛠️ In progress
+<DocsSectionTitle
+  id={'in-progress'}
+  label={'🛠️ In progress'}
+/>
 
 > Items here are actively being built and should land in the next release or two.
 
 - **OS keychain credential storage**: replace plaintext token cache with macOS Keychain, Linux Secret Service, Windows Credential Vault. [#25](https://github.com/dallen4/deadrop/issues/25)
 
-## 📋 Planned
+<DocsSectionTitle
+  id={'planned'}
+  label={'📋 Planned'}
+/>
 
 > Backlog items we've committed to building. Open or upvote an issue if your use case would benefit from prioritising one of these.
 
@@ -96,6 +110,9 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 - **Role-based env access** (Org): per-environment RBAC.
 - **Audit log + export** (Org): full activity log with CSV/JSON export.
 
-## 🗣️ Suggest a feature
+<DocsSectionTitle
+  id={'suggestion-a-feature'}
+  label={'🗣️ Suggest a feature'}
+/>
 
 Open an issue on [GitHub](https://github.com/dallen4/deadrop/issues/new) and we'll triage it. Bugs and feature requests welcome.

--- a/web/pages/docs/features/vscode.mdx
+++ b/web/pages/docs/features/vscode.mdx
@@ -1,35 +1,52 @@
+import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
+
 # 🧩 VS Code Extension
 
 > **Experimental.** The extension is published on the VS Code Marketplace but is under active
 > development, so expect rough edges. Requires a **Supporter, Pro, or Org** plan.<br/>[See pricing →](/pricing)
 
-## What it does
+<DocsSectionTitle
+  id={'what-it-does'}
+  label={'What it does'}
+/>
 
 Adds a deadrop sidebar in VS Code with two sections:
 
 - **Secrets**: drop or grab a secret without leaving the editor
 - **Vaults**: browse and manage your cloud vault environments
 
-## Installation
+<DocsSectionTitle
+  id={'installation'}
+  label={'📦 Installation'}
+/>
 
 Open the Extensions panel in VS Code and search for **deadrop**, or install from the
 [VS Code Marketplace](https://marketplace.visualstudio.com/search?term=deadrop&target=VSCode).
 
 After installing, sign in via the extension sidebar. Your plan entitlements are checked automatically.
 
-## Dropping a secret
+<DocsSectionTitle
+  id={'dropping-a-secret'}
+  label={'Dropping a secret'}
+/>
 
 1. Open the deadrop sidebar
 2. Click **New Drop** in the Secrets section
 3. Paste or type your secret
 4. Share the generated drop ID
 
-## Grabbing a secret
+<DocsSectionTitle
+  id={'grabbing-a-secret'}
+  label={'Grabbing a secret'}
+/>
 
 1. Click **Grab** in the Secrets section
 2. Enter the drop ID you received
 
-## Vault access
+<DocsSectionTitle
+  id={'vault-access'}
+  label={'Vault access'}
+/>
 
 Environments from your cloud vault(s) appear in the Vaults section. Click an entry to view or
 copy a secret value.

--- a/web/pages/docs/features/vscode.mdx
+++ b/web/pages/docs/features/vscode.mdx
@@ -3,7 +3,7 @@ import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 # 🧩 VS Code Extension
 
 > **Experimental.** The extension is published on the VS Code Marketplace but is under active
-> development, so expect rough edges. Requires a **Supporter, Pro, or Org** plan.<br/>[See pricing →](/pricing)
+> development, so expect rough edges.
 
 <DocsSectionTitle
   id={'what-it-does'}

--- a/web/pages/docs/overview.mdx
+++ b/web/pages/docs/overview.mdx
@@ -1,4 +1,5 @@
 import { InlineCode, BlockCode } from 'atoms/Code';
+import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 
 # What is deadrop?
 

--- a/web/pages/docs/overview.mdx
+++ b/web/pages/docs/overview.mdx
@@ -4,13 +4,19 @@ import { InlineCode, BlockCode } from 'atoms/Code';
 
 **deadrop** is an e2e encrypted secret sharing platform with a goal to provide platform and device agnostic secret sharing in a steamlined and easy-to-use fashion. Behind the scenes leverages the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) and WebRTC.
 
-## How it Works
+<DocsSectionTitle
+  id={'how-it-works'}
+  label={'How it Works'}
+/>
 
 Utilizing public key infrastructure patterns, deadrop uses AES (with GCM) and Eliptical Curve (ECDH) cryptographic methods to generate keys and obfuscate payloads then SHA-256 is used after handoff for verifying data integrity.
 
 All keys are exchanged through peer-to-peer connections over WebRTC allowing all key and payload communications to remain solely between the two peers ("dropper" and "grabber") and are not logged or tracked by any server-side functionality. An opaque drop ID, the dropper's peer ID, and a nonce for the drop session are stored in a redis instance. The dropper's peer ID and nonce are then retrieved for the grabber by sending GET request to the `/api/drop` endpoint.
 
-## Features
+<DocsSectionTitle
+  id={'features'}
+  label={'Features'}
+/>
 
 - ✅ raw text secret sharing
 - ✅ JSON string secret sharing
@@ -28,13 +34,19 @@ All keys are exchanged through peer-to-peer connections over WebRTC allowing all
 
 > **Plans:** deadrop offers Free, Supporter, Pro, and Org tiers.<br/>[See pricing →](/pricing)
 
-## Using the Web Application
+<DocsSectionTitle
+  id={'using-the-web-application'}
+  label={'Using the Web Application'}
+/>
 
 To use the web application, visit [https://deadrop.io](https://deadrop.io).
 
 It is also a PWA so you can also save it to your home screen on your mobile devices.
 
-## Using the CLI
+<DocsSectionTitle
+  id={'using-the-cli'}
+  label={'Using the CLI'}
+/>
 
 See the [CLI docs](/docs/features/cli) for installation and usage.
 


### PR DESCRIPTION
## Summary

**CLI: OS keychain migration + `whoami`**
- Replaces the plaintext `.deadrop/creds` file (`cosmiconfig`/`yaml`, cwd-scoped) with the OS keychain: `@napi-rs/keyring` for the npm/Node bundle, `Bun.secrets` for the compiled binary — branched inline on the build-time `DEADROP_INSTALL_METHOD` constant so each bundler dead-code-eliminates the other backend (see `specs/keytar-migration.md`).
- Reads never throw (degrade to anonymous, warn once per process on a real backend failure); writes throw a platform-appropriate error — Linux points at installing `libsecret`, macOS/Windows points at the keychain access prompt — and never fall back to plaintext storage on denial, since that would undo the point of the migration.
- One-time `migrateLegacyCreds()` deletes any leftover legacy `.deadrop/creds` file on startup and prompts a re-login.
- New `deadrop whoami` command to check sign-in state without a full login/logout cycle; doubles as a smoke test that the keychain write actually worked.
- `install.sh` now checks for `libsecret` on Linux and prints install instructions if missing.
- New unit tests: `cache.spec.ts` (all `getToken`/`setSession` outcomes, including a `require()`-vs-`vi.mock` gotcha worth knowing about), `login.spec.ts`, `logout.spec.ts`, `whoami.spec.ts`.

**Docs**
- Fixes a docs install-command injection issue and several broken/missing imports and disclaimers across `web/pages/docs/`.
- General docs formatting/content updates (FAQs, features pages, CLI docs, section titles).

**CI**
- Bumps GitHub Action deps from v4 to v6.
- Fixes `changesets/action` reading a clobbered `cli/package.json` name after `changeset:publish` (root-caused the "Package deadrop not found" crash that `createGithubReleases: false` only masked); the release workflow now leaves the working tree clean via an explicit `git checkout` step instead of restoring the name mid-script.

## Test plan
- [x] `pnpm -F cli exec tsc --noEmit` — clean on all touched files
- [x] `pnpm cli:build` — npm bundle builds; `Bun.secrets` branch confirmed dead-code-eliminated via `minifySyntax: true`
- [x] `pnpm -F cli compile` — Bun binary builds without attempting to resolve `@napi-rs/keyring`
- [x] `pnpm vitest run --project cli` — 69/69 passing
- [x] Manual: `deadrop login` → real macOS Keychain entry created, `deadrop whoami` confirms sign-in, `deadrop logout` clears it; legacy `.deadrop/creds` migration verified end-to-end
- [ ] Next real release run completes without the CI crash and the CLI binary build triggers automatically