### PR TITLE
fix: stop double-encoding CLI login redirect URL

### DIFF
--- a/.changeset/fix-cli-login-redirect-double-encode.md
+++ b/.changeset/fix-cli-login-redirect-double-encode.md
@@ -1,0 +1,12 @@
+---
+'cli': patch
+'web': patch
+'worker': patch
+---
+
+Fix `deadrop login` failing before the sign-in ticket reaches the CLI.
+The CLI no longer double-encodes the auth redirect URL, so the browser
+handoff completes instead of throwing an invalid-URL error. The web
+callback now surfaces token and redirect failures instead of silently
+redirecting with a bad token, and the sign-in token lifetime is widened
+to 60s to avoid spurious expiries.

--- a/cli/actions/login.ts
+++ b/cli/actions/login.ts
@@ -20,7 +20,7 @@ export default async function login() {
   const newUrl = new URL(LOGIN_URL);
   newUrl.searchParams.set('redirectUrl', LOCALHOST_AUTH_URL);
 
-  const url = encodeURI(newUrl.toString());
+  const url = newUrl.toString();
 
   loader.start('Opening webpage for authentication...');
 

--- a/web/pages/auth/[platform].tsx
+++ b/web/pages/auth/[platform].tsx
@@ -19,16 +19,19 @@ const PlatformAuth = () => {
   const platformKey = typeof platform === 'string' ? platform : '';
   const label = PLATFORMS[platformKey] ?? platformKey;
 
+  const notifyError = (message: string) =>
+    showNotification({
+      message,
+      color: 'red',
+      icon: <IconX />,
+      autoClose: 4500,
+    });
+
   const getTokenAndRedirect = async () => {
     const sessionToken = await clerk.session!.getToken();
 
     if (!sessionToken) {
-      showNotification({
-        message: 'Tried to authenticate without a session!',
-        color: 'red',
-        icon: <IconX />,
-        autoClose: 4500,
-      });
+      notifyError('Tried to authenticate without a session!');
       return;
     }
 
@@ -42,14 +45,29 @@ const PlatformAuth = () => {
       },
     });
 
-    const payload = await res.json();
+    const payload = await res.json().catch(() => null);
 
-    if (typeof redirectUrl === 'string') {
-      const localhostRedirect = new URL(redirectUrl);
-      localhostRedirect.searchParams.set('token', payload.token);
-
-      window.location.href = localhostRedirect.href;
+    if (!res.ok || !payload?.token) {
+      notifyError('Failed to generate a sign-in token, please try again.');
+      return;
     }
+
+    if (typeof redirectUrl !== 'string') {
+      notifyError('Missing redirect URL, restart the sign-in from your device.');
+      return;
+    }
+
+    let localhostRedirect: URL;
+    try {
+      localhostRedirect = new URL(redirectUrl);
+    } catch {
+      notifyError(`Invalid redirect URL: ${redirectUrl}`);
+      return;
+    }
+
+    localhostRedirect.searchParams.set('token', payload.token);
+
+    window.location.href = localhostRedirect.href;
   };
 
   return (

--- a/worker/src/routers/auth.ts
+++ b/worker/src/routers/auth.ts
@@ -13,7 +13,7 @@ const authRouter = hono().get(
     const { token } =
       await clerkClient.signInTokens.createSignInToken({
         userId,
-        expiresInSeconds: 25,
+        expiresInSeconds: 60,
       });
 
     return c.json({ token }, 200);


### PR DESCRIPTION
## Problem

`deadrop login` failed before the Clerk sign-in ticket ever reached the CLI.

`cli/actions/login.ts` wrapped an already percent-encoded URL in `encodeURI`, so `%3A` became `%253A`. Next peeled one encoding layer, leaving `new URL(redirectUrl)` on the callback page a still-encoded string that threw `Invalid URL`. The redirect never fired, and the manual workaround (hand-editing the address bar) blew past the 25s ticket TTL, surfacing as `This ticket is invalid` from Clerk.

## Changes

- **cli**: drop the redundant `encodeURI` in `login.ts`; `URL.toString()` is already encoded (root cause).
- **worker**: widen sign-in token TTL `25s -> 60s` to avoid spurious expiries.
- **web**: harden `getTokenAndRedirect` to fail loudly on a bad token or invalid redirect URL instead of silently redirecting with `token=undefined`.

## Testing

- Ran `pnpm test` locally: 176 tests pass. The one failing suite (`cli/tests/unit/cache.spec.ts`) is a pre-existing environment gap (`@napi-rs/keyring` not installed) unrelated to this change.
- Manual login flow verification pending against a deployed worker (TTL bump requires deploy).
