### PR TITLE
fix: migrate worker to @clerk/hono for v2 session token support

### DIFF
--- a/.changeset/worker-clerk-hono-v2-tokens.md
+++ b/.changeset/worker-clerk-hono-v2-tokens.md
@@ -1,0 +1,10 @@
+---
+'worker': patch
+---
+
+Fix the worker rejecting valid Clerk session tokens with 401 (which broke
+CLI/web sign-in at `/auth/token`). Clerk now issues v2-format session
+tokens, and the worker's `@clerk/backend` was pinned to v2 by the
+deprecated `@hono/clerk-auth`. Migrated to `@clerk/hono`, which pulls
+`@clerk/backend@3.x` and validates v2 tokens. Context API is unchanged
+(`c.var.clerkAuth()`, `c.get('clerk')`, `getAuth(c)`).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,9 +500,9 @@ importers:
 
   worker:
     dependencies:
-      '@hono/clerk-auth':
-        specifier: ^3.1.1
-        version: 3.1.1(hono@4.12.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/hono':
+        specifier: ^0.1.51
+        version: 0.1.51(hono@4.12.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@hono/zod-validator':
         specifier: ^0.4.3
         version: 0.4.3(hono@4.12.18)(zod@3.25.76)
@@ -1168,6 +1168,10 @@ packages:
     resolution: {integrity: sha512-DRwmFu6gEmzHRUeXXB5y02QxMihHDEgetSQrb0ME6KaYe29+LnenBUQAmlASXmsovIi9cBqk4hE4WHWNRXX+Bw==}
     engines: {node: '>=18.17.0'}
 
+  '@clerk/backend@3.11.5':
+    resolution: {integrity: sha512-HEpf9XlEna1uK+JhFSvIseyvviO1C4rdjv8qe3CSu/qSNMCZD69BSA12IkwBrXuopbrmngNFv/unsNV9jcUepw==}
+    engines: {node: '>=20.9.0'}
+
   '@clerk/backend@3.2.3':
     resolution: {integrity: sha512-I3YLnSioYFG+EVFBYm0ilN28+FC8H+hkqMgB5Pdl7AcotQOn3JhiZMqLel2H0P390p8FEJKQNnrvXk3BemeKKQ==}
     engines: {node: '>=20.9.0'}
@@ -1186,6 +1190,12 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/hono@0.1.51':
+    resolution: {integrity: sha512-4tJLq7vkXB8plwWrnE1TXb1t4GNS7v5SflaCdRA9L/t7H6X0PP+Gl3JOMxa4/ZmEJ7GL4BoYh6kzpsA4uVrH5A==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      hono: 4.12.18
 
   '@clerk/nextjs@6.39.1':
     resolution: {integrity: sha512-crc6nJOK+1V7kf7tMxeoOaJK9/HHGbjqWm1rW11RrRKA7lnaIeCUtO6kSy8dZ/4ZyVfUACVOwUdQM7EqwHmzWg==}
@@ -1209,6 +1219,18 @@ packages:
 
   '@clerk/shared@4.12.2':
     resolution: {integrity: sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/shared@4.25.3':
+    resolution: {integrity: sha512-WJOD9vjmCG2k5ynlpYesEXRtBgrJOvON5UV2T6NuCsVTu0dGjHSrnEo5LhUNAAYiKiwd4Mww1EXDRL9ULFkxZw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -2144,12 +2166,6 @@ packages:
     peerDependencies:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
-
-  '@hono/clerk-auth@3.1.1':
-    resolution: {integrity: sha512-wOQaxxaBsVPSNDajUkhpv+9QWwpzLp//Kjr2H3seTgbCmskhPG356GbQjH7/sjQHcgAQKnwCc0cPk4iWCIr24A==}
-    engines: {node: '>=16.x.x'}
-    peerDependencies:
-      hono: 4.12.18
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -6720,6 +6736,10 @@ packages:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
 
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
+
   js-stringify@1.0.2:
     resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
 
@@ -10636,6 +10656,15 @@ snapshots:
       - react
       - react-dom
 
+  '@clerk/backend@3.11.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/shared': 4.25.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@clerk/backend@3.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/shared': 4.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10695,6 +10724,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
 
+  '@clerk/hono@0.1.51(hono@4.12.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@clerk/backend': 3.11.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@clerk/shared': 4.25.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      hono: 4.12.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@clerk/nextjs@6.39.1(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 2.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10726,6 +10764,16 @@ snapshots:
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.5
       std-env: 3.10.0
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@clerk/shared@4.25.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.100.11
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.7
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -11339,15 +11387,6 @@ snapshots:
       '@hcaptcha/loader': 2.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@hono/clerk-auth@3.1.1(hono@4.12.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@clerk/backend': 2.33.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@clerk/shared': 3.47.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      hono: 4.12.18
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@hono/node-server@1.19.11(hono@4.12.18)':
     dependencies:
@@ -16331,6 +16370,8 @@ snapshots:
   js-base64@3.7.8: {}
 
   js-cookie@3.0.5: {}
+
+  js-cookie@3.0.7: {}
 
   js-stringify@1.0.2: {}
 

--- a/worker/package.json
+++ b/worker/package.json
@@ -11,7 +11,7 @@
     "wrangler": "^3.99.0"
   },
   "dependencies": {
-    "@hono/clerk-auth": "^3.1.1",
+    "@clerk/hono": "^0.1.51",
     "@hono/zod-validator": "^0.4.3",
     "hono": "^4.12.18",
     "shared": "workspace:*",

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -1,4 +1,4 @@
-import { clerkMiddleware } from '@hono/clerk-auth';
+import { clerkMiddleware } from '@clerk/hono';
 import { requestId } from 'hono/request-id';
 import { AppRoutes } from './constants';
 import { hono, Middleware } from './lib/http/core';

--- a/worker/src/routers/drop.ts
+++ b/worker/src/routers/drop.ts
@@ -1,5 +1,5 @@
 import { getCookie } from 'hono/cookie';
-import { getAuth } from '@hono/clerk-auth';
+import { getAuth } from '@clerk/hono';
 import { DropDetails } from '@shared/types/common';
 import { AppRouteParts } from '../constants';
 import { hono } from '../lib/http/core';


### PR DESCRIPTION
## Problem

The worker returned **401** on every authenticated request (surfaced by CLI/web sign-in failing at `/auth/token`), even with valid, correctly-signed prod session tokens.

Root cause: Clerk now issues **v2-format session tokens** (payload `v: 2`, with `fea`/`fva`/`pla` claims). The worker authenticated via the deprecated `@hono/clerk-auth`, which pins `@clerk/backend` to `^2` — too old to validate v2 tokens. The web (on `@clerk/backend@3.x`) validated the same token fine. Nothing in our code changed; Clerk changed the token format.

Verified the token itself is valid: its signing `kid` is present in the live prod JWKS, `iss`/`azp`/`sub`/`sid` all correct, not expired.

## Change

Migrate the worker from `@hono/clerk-auth` to **`@clerk/hono`** (its named successor — the deprecation warning points there), which pulls `@clerk/backend@3.x`.

Drop-in: `@clerk/hono` reads `CLERK_SECRET_KEY`/`CLERK_PUBLISHABLE_KEY` from `env(c)`, sets the identical `clerk` + `clerkAuth` context keys, and its `getAuth(c)` matches. So `c.var.clerkAuth()`, `c.get('clerk')`, and `getAuth(c)` are unchanged — only the two imports and the dependency moved.

## Testing

- `wrangler deploy --dry-run` bundles cleanly (729 KiB upload, no errors).
- Context API compatibility verified against `@clerk/hono@0.1.51` source (same `c.set('clerk'|'clerkAuth')`).
- Deploys automatically on merge (worker path filter).