### PR TITLE
feat: seed dev+prod environments and add vault env commands

### DIFF
--- a/cli/actions/vault/env.ts
+++ b/cli/actions/vault/env.ts
@@ -1,0 +1,63 @@
+import { loadConfig, saveConfig } from 'lib/config';
+import { logError, logInfo } from 'lib/log';
+import { dirname } from 'path';
+import { exit } from 'process';
+import { vaultExists } from 'db/vaults';
+import { initEnvKey } from '@shared/lib/vault';
+
+export async function vaultEnvList() {
+  const { config } = await loadConfig();
+
+  const { vaults, active_vault } = config;
+
+  const activeVault = vaultExists(vaults, active_vault.name);
+
+  if (!activeVault) {
+    logError('Active vault not found!');
+    return exit(1);
+  }
+
+  const environments = Object.keys(activeVault.environments);
+
+  environments.forEach((environment) =>
+    logInfo(
+      environment === active_vault.environment
+        ? `* ${environment}`
+        : `  ${environment}`,
+    ),
+  );
+
+  return exit(0);
+}
+
+export async function vaultEnvAdd(name: string) {
+  const { config, filepath: configPath } = await loadConfig();
+
+  const { vaults, active_vault } = config;
+
+  const activeVault = vaultExists(vaults, active_vault.name);
+
+  if (!activeVault) {
+    logError('Active vault not found!');
+    return exit(1);
+  }
+
+  if (activeVault.environments[name]) {
+    logError(`Environment '${name}' already exists!`);
+    return exit(1);
+  }
+
+  activeVault.environments[name] = await initEnvKey();
+
+  await saveConfig(
+    dirname(configPath),
+    { active_vault, vaults },
+    true,
+  );
+
+  logInfo(
+    `Environment '${name}' added to vault '${active_vault.name}'!`,
+  );
+
+  return exit(0);
+}

--- a/cli/actions/vault/index.ts
+++ b/cli/actions/vault/index.ts
@@ -1,5 +1,6 @@
 export * from './create';
 export * from './delete';
+export * from './env';
 export * from './export';
 export * from './import';
 export * from './sync';

--- a/cli/actions/vault/use.ts
+++ b/cli/actions/vault/use.ts
@@ -6,7 +6,10 @@ import { dirname } from 'path';
 import { exit } from 'process';
 import { DeadropConfig } from '@shared/types/config';
 
-export async function vaultUse(vaultNameInput: string) {
+export async function vaultUse(
+  vaultNameInput: string,
+  options: { environment?: string } = {},
+) {
   const { config, filepath: configPath } = await loadConfig();
 
   const { vaults, active_vault } = config;
@@ -21,7 +24,7 @@ export async function vaultUse(vaultNameInput: string) {
     return exit(1);
   }
 
-  if (vaultNameInput === active_vault.name) {
+  if (vaultNameInput === active_vault.name && !options.environment) {
     logInfo(
       `Vault '${chalk.bold(vaultNameInput)}' is already active...`,
     );
@@ -32,7 +35,7 @@ export async function vaultUse(vaultNameInput: string) {
     ...config,
     active_vault: {
       name: vaultNameInput,
-      environment: 'development',
+      environment: options.environment ?? active_vault.environment,
     },
     vaults,
   };

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -10,6 +10,8 @@ import { secretRemove } from 'actions/secret/remove';
 import {
   vaultCreate,
   vaultDelete,
+  vaultEnvAdd,
+  vaultEnvList,
   vaultExport,
   vaultImport,
   vaultSync,
@@ -63,12 +65,20 @@ deadrop
 
 deadrop
   .command('inject')
-  .description('run a command with vault secrets injected as env vars')
+  .description(
+    'run a command with vault secrets injected as env vars',
+  )
   .argument('<command...>', 'command to run (after --)')
   .option('-v, --vault <name>', 'vault to inject')
   .option('-e, --environment <env>', 'environment to inject')
-  .option('-c, --config <path>', 'explicit config file (JSON or YAML)')
-  .option('--no-override', 'let existing env vars win over vault values')
+  .option(
+    '-c, --config <path>',
+    'explicit config file (JSON or YAML)',
+  )
+  .option(
+    '--no-override',
+    'let existing env vars win over vault values',
+  )
   .option('--verbose', 'log injected variable names (never values)')
   .action(inject);
 
@@ -93,6 +103,7 @@ vaultRoot
   .command('use')
   .description('change the current active vault deadrop is using')
   .argument('<name>', 'name of the vault to switch to as active')
+  .option('-e, --environment <env>', 'environment to switch to')
   .action(vaultUse);
 
 vaultRoot
@@ -106,7 +117,10 @@ vaultRoot
   .command('export')
   .description('export all the secrets of the specified vault')
   .argument('<name>', 'name of the vault to export')
-  .argument('<destination>', 'path to write the exported .env file to')
+  .argument(
+    '<destination>',
+    'path to write the exported .env file to',
+  )
   .action(vaultExport);
 
 vaultRoot
@@ -124,6 +138,21 @@ vaultRoot
   )
   .argument('<name>', 'name of the vault to delete')
   .action(vaultDelete);
+
+const vaultEnvRoot = vaultRoot
+  .command('env')
+  .description('manage environments in the active vault');
+
+vaultEnvRoot
+  .command('list')
+  .description('list environments in the active vault')
+  .action(vaultEnvList);
+
+vaultEnvRoot
+  .command('add')
+  .description('add a new environment to the active vault')
+  .argument('<name>', 'name of the environment to add')
+  .action(vaultEnvAdd);
 
 // secrets commands
 

--- a/cli/tests/unit/vault-env.spec.ts
+++ b/cli/tests/unit/vault-env.spec.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/config', () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+vi.mock('lib/log', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+vi.mock('db/vaults', () => ({
+  vaultExists: vi.fn(),
+}));
+
+vi.mock('process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('process')>();
+  return { ...actual, exit: vi.fn() };
+});
+
+describe('vaultEnvList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists the environments of the active vault', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { logInfo, logError } = await import('lib/log');
+    const { exit } = await import('process');
+    const { vaultEnvList } = await import('actions/vault/env');
+
+    const vaultConfig = {
+      location: '/tmp/vault.db',
+      environments: { development: 'devkey', production: 'prodkey' },
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'development' },
+        vaults: { default: vaultConfig },
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaultConfig as any);
+
+    await vaultEnvList();
+
+    expect(logInfo).toHaveBeenCalledWith('* development');
+    expect(logInfo).toHaveBeenCalledWith('  production');
+    expect(logError).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('vaultEnvAdd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists a newly generated key for the environment', async () => {
+    const { loadConfig, saveConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { logInfo } = await import('lib/log');
+    const { exit } = await import('process');
+    const { vaultEnvAdd } = await import('actions/vault/env');
+
+    const vaultConfig = {
+      location: '/tmp/vault.db',
+      environments: { development: 'devkey' } as Record<
+        string,
+        string
+      >,
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'development' },
+        vaults: { default: vaultConfig },
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaultConfig as any);
+
+    await vaultEnvAdd('preview');
+
+    expect(vaultConfig.environments.preview).toBeDefined();
+    expect(vaultConfig.environments.preview).not.toEqual('devkey');
+    expect(saveConfig).toHaveBeenCalled();
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining("Environment 'preview' added"),
+    );
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('errors when the environment already exists', async () => {
+    const { loadConfig, saveConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { logError } = await import('lib/log');
+    const { exit } = await import('process');
+    const { vaultEnvAdd } = await import('actions/vault/env');
+
+    const vaultConfig = {
+      location: '/tmp/vault.db',
+      environments: { development: 'devkey' },
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'development' },
+        vaults: { default: vaultConfig },
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaultConfig as any);
+
+    await vaultEnvAdd('development');
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Environment 'development' already exists",
+      ),
+    );
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/cli/tests/unit/vault-use.spec.ts
+++ b/cli/tests/unit/vault-use.spec.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/config', () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+vi.mock('lib/log', () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+vi.mock('db/vaults', () => ({
+  vaultExists: vi.fn(),
+}));
+
+vi.mock('process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('process')>();
+  return { ...actual, exit: vi.fn() };
+});
+
+describe('vaultUse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves the current environment when switching vaults without -e', async () => {
+    const { loadConfig, saveConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { vaultUse } = await import('actions/vault/use');
+
+    const vaults = {
+      default: { location: '/tmp/default.db', environments: {} },
+      other: { location: '/tmp/other.db', environments: {} },
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'production' },
+        vaults,
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaults.other as any);
+
+    await vaultUse('other');
+
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        active_vault: { name: 'other', environment: 'production' },
+      }),
+      true,
+    );
+  });
+
+  it('switches the environment when -e is passed', async () => {
+    const { loadConfig, saveConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { vaultUse } = await import('actions/vault/use');
+
+    const vaults = {
+      default: { location: '/tmp/default.db', environments: {} },
+      other: { location: '/tmp/other.db', environments: {} },
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'development' },
+        vaults,
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaults.other as any);
+
+    await vaultUse('other', { environment: 'production' });
+
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        active_vault: { name: 'other', environment: 'production' },
+      }),
+      true,
+    );
+  });
+
+  it('switches environment on the same vault when -e is passed', async () => {
+    const { loadConfig, saveConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { vaultUse } = await import('actions/vault/use');
+
+    const vaults = {
+      default: { location: '/tmp/default.db', environments: {} },
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'development' },
+        vaults,
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaults.default as any);
+
+    await vaultUse('default', { environment: 'production' });
+
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        active_vault: { name: 'default', environment: 'production' },
+      }),
+      true,
+    );
+  });
+});

--- a/shared/lib/vault.ts
+++ b/shared/lib/vault.ts
@@ -13,6 +13,7 @@ export const vault = async (
   location: path,
   environments: {
     development: await initEnvKey(),
+    production: await initEnvKey(),
   },
 });
 

--- a/shared/tests/lib/vault.spec.ts
+++ b/shared/tests/lib/vault.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { vault } from 'lib/vault';
+
+describe('vault()', () => {
+  it('seeds development and production environments, each with their own key', async () => {
+    const config = await vault('/tmp/some-vault.db');
+
+    const environments = Object.keys(config.environments);
+
+    expect(environments).toEqual(
+      expect.arrayContaining(['development', 'production']),
+    );
+    expect(environments).toHaveLength(2);
+    expect(config.environments.development).not.toEqual(
+      config.environments.production,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `vault()` (`shared/lib/vault.ts`) now seeds both `development` and `production` environments on create, each with its own `initEnvKey()` — `preview`/`staging`/etc. are opt-in.
- New `deadrop vault env` command group: `env list` (environments of the active vault, marking the current one) and `env add <name>` (lazily generates a new environment key, same pattern as `addEnvToVault`).
- `cli/actions/vault/use.ts` no longer hardcodes `environment: 'development'` — accepts optional `-e <env>`, otherwise preserves the vault's current environment.
- Unit tests: `shared/tests/lib/vault.spec.ts` (dev+prod seeding), `cli/tests/unit/vault-env.spec.ts` (list/add), `cli/tests/unit/vault-use.spec.ts` (preserve vs. switch environment).

Standalone — does not touch `inject` or the worker (Phase 1 of `specs/dogfood-vault-inject-plan.md`).

## Test plan
- [x] `pnpm vitest run --project cli tests/unit/vault-env.spec.ts tests/unit/vault-use.spec.ts`
- [x] `pnpm vitest run shared/tests/lib/vault.spec.ts`
- [x] `pnpm -F cli exec tsc --noEmit` (no new errors vs. baseline)
- [x] Full workspace test suite (pre-push hook): 190/190 passed