### PR TITLE
feat: token minting + validated inject (Phase 1)

### DIFF
--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -1,24 +1,54 @@
+import { randomBytes } from 'crypto';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { initDBClient } from 'db/init';
 import { createSecretsHelpers } from '@shared/db/secrets';
 import { loadConfig, loadConfigFromPath } from 'lib/config';
+import {
+  mintVaultToken,
+  VaultNotFoundError,
+} from 'lib/auth/vault-token';
 import { runWithEnv } from 'lib/process';
 import { logError, logInfo } from 'lib/log';
+import { VaultDBConfig } from '@shared/types/config';
 
 type InjectOptions = {
   vault?: string;
   environment?: string;
   config?: string;
   override: boolean;
+  refreshToken?: boolean;
   verbose?: boolean;
 };
 
-export async function inject(
-  command: string[],
-  options: InjectOptions,
-) {
-  if (!command?.length) {
-    logError('No command provided. Usage: deadrop inject -- <command>');
-    process.exit(1);
+async function resolveVault(options: InjectOptions) {
+  const decryptionKey = process.env.DEADROP_VAULT_KEY;
+
+  // Config-free path: DEADROP_VAULT_KEY present means CI is supplying
+  // everything itself — skip loadConfig/loadConfigFromPath entirely, even
+  // if a .deadroprc happens to be discoverable on this machine.
+  if (decryptionKey) {
+    const vaultName = options.vault ?? process.env.DEADROP_VAULT;
+    const environment =
+      options.environment ?? process.env.DEADROP_ENVIRONMENT;
+
+    if (!environment) {
+      logError(
+        'No environment specified. Use -e/--environment or ' +
+          'DEADROP_ENVIRONMENT.',
+      );
+      process.exit(1);
+    }
+
+    const vault: VaultDBConfig = {
+      location: join(
+        tmpdir(),
+        `deadrop-inject-${randomBytes(8).toString('hex')}.db`,
+      ),
+      environments: { [environment]: decryptionKey },
+    };
+
+    return { vaultName, environment, vault };
   }
 
   const { config } = options.config
@@ -35,28 +65,64 @@ export async function inject(
     process.exit(1);
   }
 
-  const db = await initDBClient(vault.location, vault.cloud);
-  const { getAllSecrets } = createSecretsHelpers(vault, db);
+  return { vaultName, environment, vault };
+}
+
+export async function inject(
+  command: string[],
+  options: InjectOptions,
+) {
+  if (!command?.length) {
+    logError('No command provided. Usage: deadrop inject -- <command>');
+    process.exit(1);
+  }
+
+  const { vaultName, environment, vault } = await resolveVault(options);
+
+  let cloud = vault.cloud;
+  if (!cloud || !cloud.authToken || options.refreshToken) {
+    let minted;
+    try {
+      minted = await mintVaultToken(vaultName);
+    } catch (err) {
+      if (err instanceof VaultNotFoundError) {
+        logError(err.message);
+        process.exit(1);
+      }
+      throw err;
+    }
+    if (!minted) {
+      logError(
+        `Could not mint a Turso token for '${vaultName ?? 'default vault'}' ` +
+          `— sign in (deadrop login) or set DEADROP_API_KEY.`,
+      );
+      process.exit(1);
+    }
+    cloud = { name: vaultName ?? 'default', ...minted };
+  }
+
+  const db = await initDBClient(vault.location, cloud);
+  const { getAllSecrets } = createSecretsHelpers({ ...vault, cloud }, db);
   const secrets = await getAllSecrets(environment);
 
   const names = Object.keys(secrets);
   logInfo(
-    `Injecting ${names.length} secret(s) from '${vaultName}' (${environment})`,
+    `Injecting ${names.length} secret(s) from ` +
+      `'${vaultName ?? 'default vault'}' (${environment})`,
   );
   if (options.verbose && names.length)
     logInfo(`Variables: ${names.join(', ')}`);
 
-  const [cmd, ...args] = command;
-  let exitCode = 0;
   try {
-    exitCode = await runWithEnv(cmd, args, secrets, {
+    const [cmd, ...args] = command;
+    const exitCode = await runWithEnv(cmd, args, secrets, {
       override: options.override,
     });
+    process.exit(exitCode);
   } catch (err) {
     logError((err as Error).message);
-    exitCode = 127;
+    process.exit(127);
   } finally {
     db.$client.close();
   }
-  process.exit(exitCode);
 }

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -69,7 +69,10 @@ deadrop
     'run a command with vault secrets injected as env vars',
   )
   .argument('<command...>', 'command to run (after --)')
-  .option('-v, --vault <name>', 'vault to inject')
+  .option(
+    '-v, --vault <name>',
+    'vault to inject (optional: defaults to your default vault)',
+  )
   .option('-e, --environment <env>', 'environment to inject')
   .option(
     '-c, --config <path>',
@@ -78,6 +81,10 @@ deadrop
   .option(
     '--no-override',
     'let existing env vars win over vault values',
+  )
+  .option(
+    '--refresh-token',
+    'mint a fresh read-only Turso token via /vault/tokens',
   )
   .option('--verbose', 'log injected variable names (never values)')
   .action(inject);

--- a/cli/lib/auth/vault-token.ts
+++ b/cli/lib/auth/vault-token.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@shared/client';
+import { syncUrl as toSyncUrl } from '@shared/lib/turso/utils';
+import { getSessionToken } from './clerk';
+
+export class VaultNotFoundError extends Error {}
+
+export type MintedVaultCreds = { authToken: string; syncUrl: string };
+
+export async function mintVaultToken(
+  vaultName?: string,
+): Promise<MintedVaultCreds | null> {
+  const token = await getSessionToken();
+  if (!token) return null;
+
+  const deadropClient = createClient(process.env.DEADROP_API_URL!, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const response = await deadropClient.vault.tokens.$post({
+    json: vaultName ? { name: vaultName } : {},
+  });
+
+  if (response.status === 404) {
+    const { error } = (await response.json()) as { error: string };
+    throw new VaultNotFoundError(error);
+  }
+  if (response.status !== 201) return null;
+
+  const { token: authToken, hostname } = (await response.json()) as {
+    token: string;
+    hostname: string;
+  };
+  return { authToken, syncUrl: toSyncUrl(hostname) };
+}

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runWithEnv } from 'lib/process';
 
 describe('runWithEnv', () => {
@@ -68,8 +68,19 @@ vi.mock('lib/config', () => ({
   loadConfigFromPath: vi.fn(),
 }));
 
+vi.mock('lib/auth/vault-token', () => ({
+  mintVaultToken: vi.fn(),
+  VaultNotFoundError: class VaultNotFoundError extends Error {},
+}));
+
 describe('inject', () => {
   beforeEach(() => vi.clearAllMocks());
+
+  afterEach(() => {
+    delete process.env.DEADROP_VAULT_KEY;
+    delete process.env.DEADROP_VAULT;
+    delete process.env.DEADROP_ENVIRONMENT;
+  });
 
   it('exits 1 with no command', async () => {
     const { logError } = await import('lib/log');
@@ -85,17 +96,22 @@ describe('inject', () => {
     exitSpy.mockRestore();
   });
 
-  it('resolves the active vault/environment, runs the command, and closes the db', async () => {
+  it('resolves the active vault/environment, mints a token, runs the command, and closes the db', async () => {
     const { loadConfig } = await import('lib/config');
     const { initDBClient } = await import('db/init');
     const { createSecretsHelpers } = await import(
       '@shared/db/secrets'
     );
+    const { mintVaultToken } = await import('lib/auth/vault-token');
     const processModule = await import('lib/process');
     const { inject } = await import('actions/inject');
 
     const close = vi.fn();
     const secrets = { FOO: 'bar' };
+    const minted = {
+      authToken: 'minted-token',
+      syncUrl: 'libsql://default.turso.io',
+    };
 
     vi.mocked(loadConfig).mockResolvedValue({
       config: {
@@ -103,6 +119,7 @@ describe('inject', () => {
         vaults: { default: { location: './vault.db', environments: {} } },
       },
     } as any);
+    vi.mocked(mintVaultToken).mockResolvedValue(minted);
     vi.mocked(initDBClient).mockResolvedValue({
       $client: { close },
     } as any);
@@ -119,7 +136,11 @@ describe('inject', () => {
 
     await inject(['node', '-e', 'process.exit(3)'], { override: true });
 
-    expect(initDBClient).toHaveBeenCalledWith('./vault.db', undefined);
+    expect(mintVaultToken).toHaveBeenCalledWith('default');
+    expect(initDBClient).toHaveBeenCalledWith('./vault.db', {
+      name: 'default',
+      ...minted,
+    });
     expect(runWithEnvSpy).toHaveBeenCalledWith(
       'node',
       ['-e', 'process.exit(3)'],
@@ -132,6 +153,164 @@ describe('inject', () => {
     runWithEnvSpy.mockRestore();
   });
 
+  it('does not re-mint when the config already has a token', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } = await import(
+      '@shared/db/secrets'
+    );
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    const close = vi.fn();
+    const cloud = {
+      name: 'default',
+      syncUrl: 'libsql://default.turso.io',
+      authToken: 'existing-token',
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'dev' },
+        vaults: {
+          default: { location: './vault.db', environments: {}, cloud },
+        },
+      },
+    } as any);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue({}),
+    } as any);
+    vi.spyOn(processModule, 'runWithEnv').mockResolvedValue(0);
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await inject(['node'], { override: true });
+
+    expect(mintVaultToken).not.toHaveBeenCalled();
+    expect(initDBClient).toHaveBeenCalledWith('./vault.db', cloud);
+  });
+
+  it('--refresh-token forces a re-mint even when a token exists', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } = await import(
+      '@shared/db/secrets'
+    );
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    const close = vi.fn();
+    const cloud = {
+      name: 'default',
+      syncUrl: 'libsql://default.turso.io',
+      authToken: 'existing-token',
+    };
+    const minted = {
+      authToken: 'refreshed-token',
+      syncUrl: 'libsql://default.turso.io',
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'dev' },
+        vaults: {
+          default: { location: './vault.db', environments: {}, cloud },
+        },
+      },
+    } as any);
+    vi.mocked(mintVaultToken).mockResolvedValue(minted);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue({}),
+    } as any);
+    vi.spyOn(processModule, 'runWithEnv').mockResolvedValue(0);
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await inject(['node'], { override: true, refreshToken: true });
+
+    expect(mintVaultToken).toHaveBeenCalledWith('default');
+    expect(initDBClient).toHaveBeenCalledWith('./vault.db', {
+      name: 'default',
+      ...minted,
+    });
+  });
+
+  it('surfaces VaultNotFoundError cleanly instead of the generic message', async () => {
+    const { logError } = await import('lib/log');
+    const { loadConfig } = await import('lib/config');
+    const { mintVaultToken, VaultNotFoundError } = await import(
+      'lib/auth/vault-token'
+    );
+    const { inject } = await import('actions/inject');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'dev' },
+        vaults: { default: { location: './vault.db', environments: {} } },
+      },
+    } as any);
+    vi.mocked(mintVaultToken).mockRejectedValue(
+      new VaultNotFoundError("Vault 'default' not found."),
+    );
+
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => {
+        throw new Error('exit');
+      });
+
+    await expect(inject(['node'], { override: true })).rejects.toThrow(
+      'exit',
+    );
+
+    expect(logError).toHaveBeenCalledWith("Vault 'default' not found.");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('config-free: resolves vault from env vars without loadConfig', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } = await import(
+      '@shared/db/secrets'
+    );
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    const close = vi.fn();
+    const secrets = { FOO: 'bar' };
+    const minted = {
+      authToken: 'minted-token',
+      syncUrl: 'libsql://default.turso.io',
+    };
+
+    process.env.DEADROP_VAULT_KEY = 'aes-key';
+    process.env.DEADROP_ENVIRONMENT = 'production';
+
+    vi.mocked(mintVaultToken).mockResolvedValue(minted);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue(secrets),
+    } as any);
+    vi.spyOn(processModule, 'runWithEnv').mockResolvedValue(0);
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await inject(['node'], { override: true });
+
+    expect(loadConfig).not.toHaveBeenCalled();
+    // Default vault: no name given via -v or DEADROP_VAULT.
+    expect(mintVaultToken).toHaveBeenCalledWith(undefined);
+  });
+
   it('exits 127 with a clean error when the command is not found', async () => {
     const { logError } = await import('lib/log');
     const { loadConfig } = await import('lib/config');
@@ -139,6 +318,7 @@ describe('inject', () => {
     const { createSecretsHelpers } = await import(
       '@shared/db/secrets'
     );
+    const { mintVaultToken } = await import('lib/auth/vault-token');
     const processModule = await import('lib/process');
     const { inject } = await import('actions/inject');
 
@@ -150,6 +330,10 @@ describe('inject', () => {
         vaults: { default: { location: './vault.db', environments: {} } },
       },
     } as any);
+    vi.mocked(mintVaultToken).mockResolvedValue({
+      authToken: 'minted-token',
+      syncUrl: 'libsql://default.turso.io',
+    });
     vi.mocked(initDBClient).mockResolvedValue({
       $client: { close },
     } as any);

--- a/cli/tests/unit/vault-token.spec.ts
+++ b/cli/tests/unit/vault-token.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/auth/clerk', () => ({
+  getSessionToken: vi.fn(),
+}));
+
+vi.mock('@shared/client', () => ({
+  createClient: vi.fn(),
+}));
+
+describe('mintVaultToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DEADROP_API_URL = 'https://api.test';
+  });
+
+  it('returns null when signed out', async () => {
+    const { getSessionToken } = await import('lib/auth/clerk');
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+
+    vi.mocked(getSessionToken).mockResolvedValue(null);
+
+    const result = await mintVaultToken();
+
+    expect(result).toBeNull();
+  });
+
+  it('mints a read-only token and builds a sync url', async () => {
+    const { getSessionToken } = await import('lib/auth/clerk');
+    const { createClient } = await import('@shared/client');
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+
+    vi.mocked(getSessionToken).mockResolvedValue('session-token');
+
+    const $post = vi.fn().mockResolvedValue({
+      status: 201,
+      json: async () => ({
+        token: 'minted-token',
+        hostname: 'my-vault.turso.io',
+      }),
+    });
+    vi.mocked(createClient).mockReturnValue({
+      vault: { tokens: { $post } },
+    } as any);
+
+    const result = await mintVaultToken('my-vault');
+
+    expect($post).toHaveBeenCalledWith({ json: { name: 'my-vault' } });
+    expect(result).toEqual({
+      authToken: 'minted-token',
+      syncUrl: 'libsql://my-vault.turso.io',
+    });
+  });
+
+  it('sends an empty body when no vault name is given', async () => {
+    const { getSessionToken } = await import('lib/auth/clerk');
+    const { createClient } = await import('@shared/client');
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+
+    vi.mocked(getSessionToken).mockResolvedValue('session-token');
+
+    const $post = vi.fn().mockResolvedValue({
+      status: 201,
+      json: async () => ({
+        token: 'minted-token',
+        hostname: 'default.turso.io',
+      }),
+    });
+    vi.mocked(createClient).mockReturnValue({
+      vault: { tokens: { $post } },
+    } as any);
+
+    await mintVaultToken();
+
+    expect($post).toHaveBeenCalledWith({ json: {} });
+  });
+
+  it('throws VaultNotFoundError on a 404', async () => {
+    const { getSessionToken } = await import('lib/auth/clerk');
+    const { createClient } = await import('@shared/client');
+    const { mintVaultToken, VaultNotFoundError } = await import(
+      'lib/auth/vault-token'
+    );
+
+    vi.mocked(getSessionToken).mockResolvedValue('session-token');
+
+    const $post = vi.fn().mockResolvedValue({
+      status: 404,
+      json: async () => ({ error: "Vault 'missing' not found." }),
+    });
+    vi.mocked(createClient).mockReturnValue({
+      vault: { tokens: { $post } },
+    } as any);
+
+    await expect(mintVaultToken('missing')).rejects.toThrow(
+      VaultNotFoundError,
+    );
+  });
+
+  it('returns null on an unexpected non-201 response', async () => {
+    const { getSessionToken } = await import('lib/auth/clerk');
+    const { createClient } = await import('@shared/client');
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+
+    vi.mocked(getSessionToken).mockResolvedValue('session-token');
+
+    const $post = vi.fn().mockResolvedValue({ status: 500 });
+    vi.mocked(createClient).mockReturnValue({
+      vault: { tokens: { $post } },
+    } as any);
+
+    const result = await mintVaultToken();
+
+    expect(result).toBeNull();
+  });
+});

--- a/shared/lib/turso/client.ts
+++ b/shared/lib/turso/client.ts
@@ -1,5 +1,17 @@
 const BASE = 'https://api.turso.tech/v1/organizations';
 
+export class TursoApiError extends Error {
+  constructor(
+    public readonly status: number,
+    method: string,
+    path: string,
+    body: string,
+  ) {
+    super(`Turso API ${method} ${path} (${status}): ${body}`);
+    this.name = 'TursoApiError';
+  }
+}
+
 export type TursoClient = ReturnType<typeof createTursoClient>;
 
 export const createTursoClient = (
@@ -26,9 +38,7 @@ export const createTursoClient = (
 
     if (!res.ok) {
       const text = await res.text();
-      throw new Error(
-        `Turso API ${method} ${path} (${res.status}): ${text}`,
-      );
+      throw new TursoApiError(res.status, method, path, text);
     }
 
     const contentType = res.headers.get('content-type');

--- a/shared/lib/turso/index.ts
+++ b/shared/lib/turso/index.ts
@@ -3,7 +3,7 @@ import { createTursoClient } from './client';
 import { createLifecycleHandlers } from './lifecycle';
 import { createProvisionHandlers } from './provision';
 
-export { createTursoClient } from './client';
+export { createTursoClient, TursoApiError } from './client';
 export type { TursoClient } from './client';
 export { createProvisionHandlers } from './provision';
 export { createLifecycleHandlers } from './lifecycle';

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -14,7 +14,7 @@ export type VaultEnvironments = {
 export type CloudVaultConfig = {
   name: string;
   syncUrl: string;
-  authToken: string;
+  authToken?: string;
 };
 
 export type VaultDBConfig = {

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -21,7 +21,7 @@ worker/
 │   │   ├── auth.ts           # Clerk auth endpoints
 │   │   ├── peers.ts          # PeerJS signaling (upgrades to WebSocket → Durable Object)
 │   │   ├── drop.ts           # Drop CRUD (Redis-backed)
-│   │   └── vault.ts          # Vault create/share/get/delete/lock/unlock (Turso via @shared/lib/turso)
+│   │   └── vault.ts          # Vault create/tokens/get/delete/lock/unlock (Turso via @shared/lib/turso)
 │   └── lib/
 │       ├── http/core.ts      # Hono instance + custom context/middleware types
 │       ├── middleware.ts     # cors, tracing, redis, authenticated(), restricted(), service()
@@ -52,7 +52,7 @@ worker/
 | `*` | `/peers/*` | PeerJS signaling via `PeerServerDO` — implemented but not live (see top of file); production uses `peers.deadrop.io` on Render |
 | GET/POST/DELETE | `/drop` | Drop session CRUD (Redis) |
 | POST | `/vault` | Create a Turso vault database (`restricted()`) |
-| POST | `/vault/share` | Share a vault with another user (`restricted()`) |
+| POST | `/vault/tokens` | Mint a read-only Turso token for a vault (`restricted({ allowApiKey: true })`) |
 | GET | `/vault/:name` | Get vault metadata (`authenticated()`) |
 | DELETE | `/vault/:name` | Delete a vault (`restricted()`) |
 | POST | `/vault/lock` | Lock all of a user's vaults on cancel (`service()`, `{ userId }`) |
@@ -88,7 +88,7 @@ worker/
 
 ### Vaults — Turso
 - Provisioning + lifecycle live in `shared/lib/turso/` (`createVaultUtils`) — see `shared/lib/turso/CLAUDE.md`. The former `worker/src/lib/vault.ts` was collapsed into it.
-- `vault.ts` router: create/share/get are `restricted()`/`authenticated()` (early-access/internal, per-user Clerk claim); `lock`/`unlock` are `service()`-gated for billing webhooks
+- `vault.ts` router: create/tokens/get are `restricted()`/`authenticated()` (early-access/internal, per-user Clerk claim; `/vault/tokens` also allows `DEADROP_API_KEY` via `allowApiKey: true`, for CI/`inject`); `lock`/`unlock` are `service()`-gated for billing webhooks
 - Cancel-on-billing fans out over **all** of a user's vaults via `listVaults(<hash13>)`; org-payer cancellations are a known gap (vaults are named per user, not per org)
 
 ### Billing/plans (`src/lib/billing.ts`)

--- a/worker/src/constants.ts
+++ b/worker/src/constants.ts
@@ -28,7 +28,7 @@ export const AppRouteParts = {
   // vaults
   VaultRoot: '/vault',
   NameParam: '/:name',
-  Share: '/:name/share',
+  Tokens: '/tokens',
   Lock: '/lock',
   Unlock: '/unlock',
 
@@ -53,7 +53,7 @@ export const AppRoutes = {
 
   // vault paths
   VaultRoot: AppRouteParts.VaultRoot,
-  ShareVault: `${AppRouteParts.VaultRoot}${AppRouteParts.NameParam}${AppRouteParts.Share}` as const,
+  VaultTokens: `${AppRouteParts.VaultRoot}${AppRouteParts.Tokens}` as const,
   LockVault: `${AppRouteParts.VaultRoot}${AppRouteParts.Lock}` as const,
   UnlockVault: `${AppRouteParts.VaultRoot}${AppRouteParts.Unlock}` as const,
 } as const;

--- a/worker/src/routers/vault.ts
+++ b/worker/src/routers/vault.ts
@@ -5,6 +5,7 @@ import { hono } from '../lib/http/core';
 import {
   createVaultUtils,
   vaultNameFromUserId,
+  TursoApiError,
 } from '@shared/lib/turso';
 import {
   authenticated,
@@ -17,6 +18,7 @@ const CreateVaultSchema = VaultNameSchema.partial().extend({
   seed: z.enum(['database_upload']).optional(),
 });
 const VaultOwnerSchema = z.object({ userId: z.string() });
+const VaultTokenSchema = z.object({ name: z.string().optional() });
 
 const vaultRouter = hono()
   .post(
@@ -61,13 +63,13 @@ const vaultRouter = hono()
     },
   )
   .post(
-    AppRouteParts.Share,
+    AppRouteParts.Tokens,
     restricted({ allowApiKey: true }),
-    zValidator('json', VaultNameSchema),
+    zValidator('json', VaultTokenSchema),
     async (c) => {
       const userId = c.get('userId')!;
 
-      const { createVaultToken } = createVaultUtils(
+      const { createVaultToken, getVault } = createVaultUtils(
         c.env.TURSO_ORGANIZATION,
         c.env.TURSO_PLATFORM_API_TOKEN,
       );
@@ -77,10 +79,23 @@ const vaultRouter = hono()
       try {
         const vaultName = await vaultNameFromUserId(userId!, name);
 
-        const token = await createVaultToken(vaultName, 'read-only');
+        const [vault, token] = await Promise.all([
+          getVault(vaultName),
+          createVaultToken(vaultName, 'read-only'),
+        ]);
 
-        return c.json({ token }, 201);
+        return c.json({ token, hostname: vault?.Hostname }, 201);
       } catch (error) {
+        if (error instanceof TursoApiError && error.status === 404) {
+          return c.json(
+            {
+              error: name
+                ? `Vault '${name}' not found.`
+                : 'No default vault found for this account.',
+            },
+            404,
+          );
+        }
         return c.json(
           { error: `Unexpected error: ${(error as Error).message}` },
           500,

--- a/worker/tests/routers/vault-tokens.spec.ts
+++ b/worker/tests/routers/vault-tokens.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createMiddleware } from 'hono/factory';
+import { TursoApiError } from '@shared/lib/turso';
+
+vi.mock('../../src/lib/middleware', () => ({
+  authenticated: () => createMiddleware(async (_c, next) => next()),
+  restricted: () =>
+    createMiddleware(async (c, next) => {
+      c.set('userId', 'user_123');
+      await next();
+    }),
+  service: () => createMiddleware(async (_c, next) => next()),
+}));
+
+const getVault = vi.fn();
+const createVaultToken = vi.fn();
+
+vi.mock('@shared/lib/turso', async () => {
+  const actual = await vi.importActual<typeof import('@shared/lib/turso')>(
+    '@shared/lib/turso',
+  );
+  return {
+    ...actual,
+    vaultNameFromUserId: vi.fn(async (userId: string, name?: string) =>
+      name ? `hash13-${name}` : 'hash13',
+    ),
+    createVaultUtils: () => ({ getVault, createVaultToken }),
+  };
+});
+
+const testEnv = {
+  TURSO_ORGANIZATION: 'test-org',
+  TURSO_PLATFORM_API_TOKEN: 'test-token',
+};
+
+describe('POST /vault/tokens', () => {
+  it('mints a read-only token and returns the hostname', async () => {
+    vi.clearAllMocks();
+    getVault.mockResolvedValue({ Hostname: 'my-vault.turso.io' });
+    createVaultToken.mockResolvedValue('read-only-jwt');
+
+    const vaultRouter = (await import('../../src/routers/vault')).default;
+    const res = await vaultRouter.request(
+      '/tokens',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      token: 'read-only-jwt',
+      hostname: 'my-vault.turso.io',
+    });
+    expect(createVaultToken).toHaveBeenCalledWith('hash13', 'read-only');
+  });
+
+  it('resolves a named vault via vaultNameFromUserId(userId, name)', async () => {
+    vi.clearAllMocks();
+    getVault.mockResolvedValue({ Hostname: 'named-vault.turso.io' });
+    createVaultToken.mockResolvedValue('read-only-jwt');
+
+    const vaultRouter = (await import('../../src/routers/vault')).default;
+    const res = await vaultRouter.request(
+      '/tokens',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'demo' }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(201);
+    expect(createVaultToken).toHaveBeenCalledWith(
+      'hash13-demo',
+      'read-only',
+    );
+  });
+
+  it('returns a clean 404 when the vault does not exist', async () => {
+    vi.clearAllMocks();
+    getVault.mockRejectedValue(
+      new TursoApiError(404, 'GET', '/missing', 'not found'),
+    );
+    createVaultToken.mockRejectedValue(
+      new TursoApiError(404, 'POST', '/missing/auth/tokens', 'not found'),
+    );
+
+    const vaultRouter = (await import('../../src/routers/vault')).default;
+    const res = await vaultRouter.request(
+      '/tokens',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'missing' }),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: "Vault 'missing' not found.",
+    });
+  });
+
+  it('returns 500 for any other error', async () => {
+    vi.clearAllMocks();
+    getVault.mockRejectedValue(new Error('boom'));
+    createVaultToken.mockResolvedValue('read-only-jwt');
+
+    const vaultRouter = (await import('../../src/routers/vault')).default;
+    const res = await vaultRouter.request(
+      '/tokens',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+      testEnv,
+    );
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /vault/tokens`: mints a read-only Turso token for a named or default vault, gated `restricted({ allowApiKey: true })`. Replaces the unused `POST /vault/:name/share` route (confirmed dead code, no callers anywhere in the monorepo). Returns a clean 404 (via new `TursoApiError`) instead of a raw 500 when the vault doesn't exist.
- `CloudVaultConfig.authToken` is now optional, since a config-free CI run has none stored.
- `cli/lib/auth/vault-token.ts`: `mintVaultToken` calls the new route through `getSessionToken()` (so the existing `DEADROP_API_KEY` fallback applies) and returns `{ authToken, syncUrl }`.
- `deadrop inject` rewrite: auto-mints a token when the resolved vault has none (or `--refresh-token` is passed), and supports a fully config-free path via `DEADROP_VAULT_KEY`/`DEADROP_VAULT`/`DEADROP_ENVIRONMENT` env vars, no `.deadroprc` required. Output stays the existing subprocess-exec (`runWithEnv`); `--github-env` is explicitly deferred to a follow-up.

This is a replant of already-written work from a reference worktree (`cli-inject-ci`), ported onto alpha's foundation. Alpha's existing `DEADROP_API_KEY` fallback (`cli/lib/auth/clerk.ts`) and `restricted({ allowApiKey: true })` (`worker/src/lib/middleware.ts`) were left untouched, this builds on top of them, not around them.

## Test plan
- [x] `pnpm -F cli test` green (one pre-existing, unrelated `crypto.spec.ts` fixture-file failure, confirmed present before this branch's changes too)
- [x] `pnpm -F worker test` green, including new `worker/tests/routers/vault-tokens.spec.ts` (mint / named-vault / 404 / 500 cases)
- [x] `tsc --noEmit` on `cli/` and `worker/` clean aside from pre-existing, unrelated errors (confirmed present on `alpha` before this branch too)
- [ ] Live validation gate (real cloud vault + signed-in internal identity), deferred to a prod smoke test since exercising it requires a manual worker deploy + local CLI build outside the normal pipeline