### PR TITLE
fix: local-vault inject + release tag ordering

### DIFF
--- a/.changeset/inject-local-vault-no-mint.md
+++ b/.changeset/inject-local-vault-no-mint.md
@@ -1,0 +1,5 @@
+---
+'cli': patch
+---
+
+Fix `deadrop inject` failing with "Vault not found" on local (non-cloud) vaults. It now only mints a cloud token for cloud vaults or the config-free CI path; local vaults read directly from their SQLite file with no network call.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,26 @@ jobs:
           PUBLISHED: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           version=$(echo "$PUBLISHED" | jq -r '.[] | select(.name == "deadrop") | .version')
-          if [ -n "$version" ]; then
-            echo "Dispatching CLI binary build for deadrop@${version}"
-            gh workflow run cli_publish_workflow.yml --ref "deadrop@${version}"
-          else
+          if [ -z "$version" ]; then
             echo "deadrop package not in published set; skipping binary build"
+            exit 0
           fi
+          tag="deadrop@${version}"
+          # changeset publish's tag isn't reliably on origin when we dispatch by
+          # ref below, so create + push it ourselves (idempotent) first.
+          git tag "$tag" 2>/dev/null || true
+          git push origin "refs/tags/$tag" 2>/dev/null || true
+          # Wait for the ref to be resolvable before dispatching, else GitHub
+          # returns 422 No ref found.
+          for i in $(seq 1 10); do
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/$tag" >/dev/null 2>&1; then
+              break
+            fi
+            echo "waiting for $tag to appear on origin ($i)..."
+            sleep 3
+          done
+          echo "Dispatching CLI binary build for $tag"
+          gh workflow run cli_publish_workflow.yml --ref "$tag"
       - name: Restore cli/package.json name
         if: always()
         run: git checkout -- cli/package.json

--- a/cli/actions/inject.ts
+++ b/cli/actions/inject.ts
@@ -92,7 +92,9 @@ export async function inject(
     await resolveVault(options);
 
   let cloud = vault.cloud;
-  if (!cloud || !cloud.authToken || options.refreshToken) {
+  // only cloud vaults or the config-free CI path mint a token
+  const usesCloud = ephemeral || !!cloud;
+  if (usesCloud && (!cloud?.authToken || options.refreshToken)) {
     let minted;
     try {
       minted = await mintVaultToken(vaultName);

--- a/cli/tests/unit/inject.spec.ts
+++ b/cli/tests/unit/inject.spec.ts
@@ -121,7 +121,16 @@ describe('inject', () => {
     vi.mocked(loadConfig).mockResolvedValue({
       config: {
         active_vault: { name: 'default', environment: 'dev' },
-        vaults: { default: { location: './vault.db', environments: {} } },
+        vaults: {
+          default: {
+            location: './vault.db',
+            environments: {},
+            cloud: {
+              name: 'default',
+              syncUrl: 'libsql://default.turso.io',
+            },
+          },
+        },
       },
     } as any);
     vi.mocked(mintVaultToken).mockResolvedValue(minted);
@@ -198,6 +207,39 @@ describe('inject', () => {
     expect(initDBClient).toHaveBeenCalledWith('./vault.db', cloud);
   });
 
+  it('local vault (no cloud config): does not mint, reads locally', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { initDBClient } = await import('db/init');
+    const { createSecretsHelpers } = await import(
+      '@shared/db/secrets'
+    );
+    const { mintVaultToken } = await import('lib/auth/vault-token');
+    const processModule = await import('lib/process');
+    const { inject } = await import('actions/inject');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'dev' },
+        vaults: {
+          default: { location: './vault.db', environments: {} },
+        },
+      },
+    } as any);
+    vi.mocked(initDBClient).mockResolvedValue({
+      $client: { close: vi.fn() },
+    } as any);
+    vi.mocked(createSecretsHelpers).mockReturnValue({
+      getAllSecrets: vi.fn().mockResolvedValue({}),
+    } as any);
+    vi.spyOn(processModule, 'runWithEnv').mockResolvedValue(0);
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    await inject(['node'], { override: true });
+
+    expect(mintVaultToken).not.toHaveBeenCalled();
+    expect(initDBClient).toHaveBeenCalledWith('./vault.db', undefined);
+  });
+
   it('--refresh-token forces a re-mint even when a token exists', async () => {
     const { loadConfig } = await import('lib/config');
     const { initDBClient } = await import('db/init');
@@ -257,7 +299,16 @@ describe('inject', () => {
     vi.mocked(loadConfig).mockResolvedValue({
       config: {
         active_vault: { name: 'default', environment: 'dev' },
-        vaults: { default: { location: './vault.db', environments: {} } },
+        vaults: {
+          default: {
+            location: './vault.db',
+            environments: {},
+            cloud: {
+              name: 'default',
+              syncUrl: 'libsql://default.turso.io',
+            },
+          },
+        },
       },
     } as any);
     vi.mocked(mintVaultToken).mockRejectedValue(


### PR DESCRIPTION
## Summary
Two post-v1.4.0 fast-follows surfaced by dogfooding the vault flow and by the last CLI release:
- `deadrop inject` no longer fails on **local** vaults (it was unconditionally trying to mint a cloud token).
- The Release workflow ensures the `deadrop@<version>` tag is on origin **before** dispatching the CLI binary build, so binaries stop requiring a manual tag push.

## Changes

### fix: skip cloud token minting for local vaults (`30c68e8`)
- `cli/actions/inject.ts`: gate minting on `usesCloud = ephemeral || !!cloud`. Local vaults (no `cloud` config) now read their SQLite file directly with no network call; only cloud vaults and the config-free CI path mint a `/vault/tokens` token.
- Fixes `inject` erroring with `Vault '<name>' not found.` on a plain local vault.
- `cli/tests/unit/inject.spec.ts`: added a `local vault: does not mint, reads locally` regression test; corrected two existing tests that had encoded the buggy behavior (they used a local vault but asserted minting — now use a cloud vault, which is what legitimately triggers a mint).
- Changeset: `cli: patch`.

### ci: put the deadrop tag on origin before dispatching binaries (`2ad48a6`)
- `.github/workflows/release.yml`: the "Trigger CLI binary release" step now creates + pushes `deadrop@<version>` (idempotent) and polls until the ref is resolvable before `gh workflow run --ref`. Previously it dispatched by ref immediately after publish, hitting `HTTP 422: No ref found`, which silently skipped the binaries and forced a manual tag push.
- Non-regressive: if the tag push ever fails, the poll times out and it dispatches anyway — same manual-push fallback as today.
- No changeset (workflow config, not a published package).

## Testing
- [x] `pnpm vitest run cli/tests/unit/inject.spec.ts` — 15/15 green
- [x] Local-vault `inject` validated by hand against a real local vault build
- [x] `release.yml` YAML validated
- [ ] Post-merge: the `deadrop@1.4.1` publish is the live test of the tag fix — the binary build should fire as `workflow_dispatch` and go green with no manual tag push