### PR TITLE
chore: add missed changeset for worker auth gate refactor

### DIFF
--- a/.changeset/worker-auth-gate-layering.md
+++ b/.changeset/worker-auth-gate-layering.md
@@ -1,0 +1,5 @@
+---
+'worker': minor
+---
+
+Restructure vault route auth into layered `authenticated()` + `restricted()` gates: `authenticated()` owns token-type acceptance (session/OAuth always, API keys per-route via `allowApiKey`) and resolves `userId`; `restricted()` now always checks `early_access`/`internal` against the owner's live Clerk metadata. `GET /vault/:name` additionally accepts API-key tokens.


### PR DESCRIPTION
## Summary
The worker changeset from #134 never reached origin — the PR merged a pre-rebase alpha that didn't include it, so changesets had nothing to version. This adds the changeset back (worker minor: auth gate layering, `GET /vault/:name` API-key acceptance). Merging opens the version PR minting `worker@1.2.0`.