### PR TITLE
fix: vault row icons + docs hydration

### DIFF
--- a/.changeset/vault-row-icon-escapes.md
+++ b/.changeset/vault-row-icon-escapes.md
@@ -1,0 +1,5 @@
+---
+'deadrop-vsc': patch
+---
+
+Fix vault row action buttons rendering literal `\uXXXX` text instead of their icons — bare unicode escapes in JSX text nodes aren't parsed as string escapes; wrap them in expressions.

--- a/vscode-extension/CLAUDE.md
+++ b/vscode-extension/CLAUDE.md
@@ -7,14 +7,17 @@ VS Code extension providing deadrop's e2e encrypted secret sharing directly in t
 ```bash
 pnpm vscode:build          # Production build (esbuild + vite)
 pnpm vscode:dev            # Watch mode for extension host only
-pnpm vscode:package        # Package .vsix (vsce --no-dependencies)
-pnpm vscode:publish        # Publish to marketplace (vsce --no-dependencies)
+pnpm vscode:package        # Stage native libsql + package .vsix (vsce --no-dependencies)
+pnpm vscode:publish        # Stage native libsql + publish to marketplace (vsce --no-dependencies)
+pnpm -F deadrop-vsc stage-native  # Stage the native libsql binding into dist/node_modules
 pnpm -F deadrop-vsc views:build   # Build webview only (Vite)
 pnpm -F deadrop-vsc views:dev     # Vite dev server (HMR)
 pnpm -F deadrop-vsc check-types   # Type check both src/ and views/
 ```
 
 Press **F5** from the monorepo root to launch the Extension Development Host (runs `vscode:build` preLaunchTask automatically).
+
+**Releases are CI-automated.** The `vscode-extension` job in `.github/workflows/release.yml` (runs on merge to `main`) compares `package.json` against the marketplace and publishes 7 per-platform vsixes only when the local version is ahead — independent of the CLI/npm release. Bump `deadrop-vsc` via a changeset; the manual `vscode:publish` is a fallback. See `scripts/stage-native.js` and the Build System section for the native-packaging details.
 
 ## Directory Structure
 
@@ -32,6 +35,7 @@ vscode-extension/
 │       ├── vscode.ts    # typed postMessage/onMessage wrappers
 │       └── lib/          # peer.ts (initPeerFromConfig), session.ts (cleanupSession)
 ├── scripts/esbuild.js   # Extension host build config — see Build System below
+├── scripts/stage-native.js  # Stages native libsql binding into dist/node_modules for the vsix — see Build System
 ├── vite.config.ts       # Webview build config — see Build System below
 ├── tsconfig.json        # Extension host (CommonJS)
 └── tsconfig.views.json  # Webview (ESM, jsx: react-jsx)
@@ -44,11 +48,16 @@ Two separate build steps, both run by `pnpm vscode:build`:
 ### Extension Host — esbuild (`scripts/esbuild.js`)
 - Entry: `src/extension.ts` → `dist/extension.js`
 - Format: CommonJS, platform: Node
-- `vscode` is external (provided by VS Code at runtime)
+- Bundles pure-JS deps (`@libsql/client`, `drizzle-orm`, `cosmiconfig`, …) into the output. Externals are only `vscode` (provided by VS Code), `libsql` (native binding, staged separately), and ws's optional natives `bufferutil`/`utf-8-validate`
 - Env vars baked at build time via esbuild `define` from `.env`:
   - `DEADROP_API_URL`, `PEER_SERVER_URL`, `TURN_USERNAME`, `TURN_PWD`, `CLERK_PUBLISHABLE_KEY`
 - `@shared` alias → `../../shared` (relative from `scripts/`)
 - Source maps in dev; minified in production (`--production` flag)
+
+### Native packaging — stage-native.js (`scripts/stage-native.js`)
+- esbuild can't bundle native `.node` binaries, and `vsce --no-dependencies` drops top-level `node_modules` — so `stage-native.js` copies `libsql` + `@neon-rs/load` + `detect-libc` + the target platform's `@libsql/*` binary into `dist/node_modules`, where `require('libsql')` from `dist/extension.js` resolves it inside the vsix
+- Takes an optional vsce target (`darwin-arm64`, `linux-x64`, `win32-x64`, …); defaults to the host platform. Non-host binaries are fetched via `npm pack` at the version pinned by the installed `libsql`
+- Runs automatically before `vscode:package`/`vscode:publish`; CI loops it over all 7 targets
 
 ### Webview — Vite (`vite.config.ts`)
 - Root: `views/`

--- a/vscode-extension/src/auth/clerk.ts
+++ b/vscode-extension/src/auth/clerk.ts
@@ -117,7 +117,6 @@ export async function hasCloudAccess(): Promise<boolean> {
     const payload = JSON.parse(
       Buffer.from(jwt.split('.')[1], 'base64').toString(),
     );
-    console.log("PAYLOAD", payload);
     return !!(payload.early_access || payload.internal);
   } catch {
     return false;

--- a/vscode-extension/views/src/molecules/EnvSidebar.tsx
+++ b/vscode-extension/views/src/molecules/EnvSidebar.tsx
@@ -80,7 +80,7 @@ export default function EnvSidebar({
               onClick={() => setAddEnvOpen(false)}
               disabled={addingEnv}
             >
-              \u2715
+              {'\u2715'}
             </button>
           </div>
         </form>

--- a/vscode-extension/views/src/molecules/SecretRow.tsx
+++ b/vscode-extension/views/src/molecules/SecretRow.tsx
@@ -185,7 +185,7 @@ export default function SecretRow({
               title="Cancel"
               aria-label="Cancel"
             >
-              \u2715
+              {'\u2715'}
             </IconButton>
           </>
         ) : (
@@ -202,7 +202,7 @@ export default function SecretRow({
               title="Rename"
               aria-label="Rename"
             >
-              \u270E
+              {'\u270E'}
             </IconButton>
           </>
         )}
@@ -239,7 +239,7 @@ export default function SecretRow({
               title="Cancel"
               aria-label="Cancel"
             >
-              \u2715
+              {'\u2715'}
             </IconButton>
           </>
         ) : (
@@ -268,14 +268,14 @@ export default function SecretRow({
                 title="Copy"
                 aria-label="Copy"
               >
-                \u29C9
+                {'\u29C9'}
               </IconButton>
               <IconButton
                 onClick={startEditValue}
                 title="Edit value"
                 aria-label="Edit value"
               >
-                \u270E
+                {'\u270E'}
               </IconButton>
               {confirmDelete ? (
                 <>
@@ -288,14 +288,14 @@ export default function SecretRow({
                     title="Confirm delete"
                     aria-label="Confirm delete"
                   >
-                    \u2713
+                    {'\u2713'}
                   </IconButton>
                   <IconButton
                     onClick={() => setConfirmDelete(false)}
                     title="Cancel"
                     aria-label="Cancel"
                   >
-                    \u2715
+                    {'\u2715'}
                   </IconButton>
                 </>
               ) : (

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -91,7 +91,7 @@ No. deadrop has three surfaces:
 
 - **Web app**: `deadrop.io`, also installable as a PWA
 - **CLI**: `deadrop` on npm or via the install script. Runs on macOS, Linux, and Windows
-- **VS Code extension**: drop, grab, and browse vaults directly from your editor (experimental, Supporter+ plans)
+- **VS Code extension**: drop, grab, and manage local or cloud-synced vaults directly from your editor (experimental, Supporter+ plans)
 
 All three implement the same cryptographic protocol and can interoperate. For example, you can drop from the CLI and grab in the browser.
 

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -36,6 +36,14 @@ Then invoke it through your package runner:
 npx deadrop [command]
 ```
 
+### Updating
+
+Keep the CLI current with the built-in updater. It detects how you installed deadrop and updates in place, whether that's the prebuilt binary or the npm package:
+
+```
+deadrop update
+```
+
 ### Requirements
 
 For the npm install path: Node.js 20 or newer. The install.sh binary has no runtime dependencies.

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -35,7 +35,7 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 ### Surfaces
 
 - **Web app**: `deadrop.io`, installable as a PWA
-- **CLI**: drop, grab, vault, secret, inject commands. Available on npm and via the install script
+- **CLI**: drop, grab, vault, secret, inject, and self-update commands. Available on npm and via the install script
 
 ### CI/CD
 
@@ -52,7 +52,7 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 ### Editor integration
 
-- **VS Code extension** (Supporter+): live on the [VS Code Marketplace](https://marketplace.visualstudio.com/search?term=deadrop&target=VSCode). Drop, grab, and browse vaults without leaving your editor. Actively iterating, so expect breaking changes between releases. <br/>[Track on GitHub →](https://github.com/dallen4/deadrop/issues)
+- **VS Code extension** (Supporter+): live on the [VS Code Marketplace](https://marketplace.visualstudio.com/search?term=deadrop&target=VSCode). Drop, grab, and manage local or cloud-synced vaults without leaving your editor. Actively iterating, so expect breaking changes between releases. <br/>[Track on GitHub →](https://github.com/dallen4/deadrop/issues)
 
 ### Vaults
 

--- a/web/pages/docs/features/vscode.mdx
+++ b/web/pages/docs/features/vscode.mdx
@@ -13,7 +13,7 @@ import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 Adds a deadrop sidebar in VS Code with two sections:
 
 - **Secrets**: drop or grab a secret without leaving the editor
-- **Vaults**: browse and manage your cloud vault environments
+- **Vaults**: create and manage vault environments — local or cloud-synced — without leaving the editor
 
 <DocsSectionTitle
   id={'installation'}
@@ -48,5 +48,6 @@ After installing, sign in via the extension sidebar. Your plan entitlements are 
   label={'Vault access'}
 />
 
-Environments from your cloud vault(s) appear in the Vaults section. Click an entry to view or
-copy a secret value.
+Your vaults appear in the Vaults section. Open one to browse its environments, reveal or copy
+secret values, and add, edit, or delete secrets. Local vaults live in your workspace; if you
+have cloud access, you can convert a local vault to a cloud-synced one from the vault view.

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -51,10 +51,10 @@ worker/
 | `*` | `/auth/*` | Clerk auth endpoints |
 | `*` | `/peers/*` | PeerJS signaling via `PeerServerDO` — implemented but not live (see top of file); production uses `peers.deadrop.io` on Render |
 | GET/POST/DELETE | `/drop` | Drop session CRUD (Redis) |
-| POST | `/vault` | Create a Turso vault database (`restricted()`) |
-| POST | `/vault/tokens` | Mint a read-only Turso token for a vault (`restricted({ allowApiKey: true })`) |
-| GET | `/vault/:name` | Get vault metadata (`authenticated()`) |
-| DELETE | `/vault/:name` | Delete a vault (`restricted()`) |
+| POST | `/vault` | Create a Turso vault database (`authenticated({ allowApiKey: true })` + `restricted()`) |
+| POST | `/vault/tokens` | Mint a read-only Turso token for a vault (`authenticated({ allowApiKey: true })` + `restricted()`) |
+| GET | `/vault/:name` | Get vault metadata (`authenticated({ allowApiKey: true })`) |
+| DELETE | `/vault/:name` | Delete a vault (`authenticated()` + `restricted()`) |
 | POST | `/vault/lock` | Lock all of a user's vaults on cancel (`service()`, `{ userId }`) |
 | POST | `/vault/unlock` | Restore all of a user's vaults on reactivate (`service()`, `{ userId }`) |
 
@@ -68,9 +68,9 @@ worker/
 5. `redis()` — attaches an Upstash client to `c.get('redis')`
 
 ### Auth gates (`src/lib/middleware.ts`)
-- Both gates take `{ allowApiKey?: boolean }` and call `getAuth(c, { acceptsToken: 'any' })` directly (not `c.var.clerkAuth()`, which defaults to session-tokens-only), then gate on `auth.tokenType` themselves. `acceptsToken` as a `TokenType[]` array doesn't type-narrow the way you'd expect — TS can't tell which literal token types were actually pushed, so the return type keeps `m2m_token` (never used anywhere in this app) in the union, and `m2m_token`'s auth object has no `userId` at all; requesting `'any'` and branching on `auth.tokenType` sidesteps that entirely. On success they `c.set('userId', ...)` — route handlers read `c.get('userId')!`, never `c.var.clerkAuth().userId!`, so the resolved identity always matches whichever token type actually authenticated.
-- `authenticated()` — 401s unless `auth.tokenType` is `session_token`/`oauth_token`, or `api_key` with `allowApiKey: true`
-- `restricted()` — 401s unless early_access/internal is set. For session tokens that's `sessionClaims.early_access`/`.internal` (Clerk publicMetadata via the JWT template). For OAuth/API-key tokens there's no session claims — it looks up the owning user's *live* Clerk metadata instead (`c.var.clerk.users.getUser(auth.userId)`); org-scoped API keys (no `userId`) are denied since vaults are per-user.
+- The two gates are **layered, not standalone**: `authenticated()` resolves identity and `c.set('userId', ...)`; `restricted()` reads that `userId` back and gates on entitlement. A `restricted()` route must chain `authenticated()` before it, or `c.get('userId')` is undefined.
+- `authenticated({ allowApiKey?: boolean })` — calls `getAuth(c, { acceptsToken: 'any' })` directly (not `c.var.clerkAuth()`, which defaults to session-tokens-only) and gates on `auth.tokenType` itself: 401s unless the type is `session_token`/`oauth_token`, or `api_key` with `allowApiKey: true`. Requesting `'any'` (rather than an `acceptsToken` array) is deliberate — a `TokenType[]` array doesn't type-narrow, so the return type keeps `m2m_token` (unused here, and its auth object has no `userId`) in the union. The single `if (!userId)` 401 also catches org-scoped API keys, whose `userId` is `null`. On success `c.set('userId', ...)` — handlers read `c.get('userId')!`, never `c.var.clerkAuth().userId!`, so identity always matches whichever token type actually authenticated.
+- `restricted()` — takes no options; reads `c.get('userId')` (set by a preceding `authenticated()`) and 401s unless `early_access`/`internal` is set. Always resolves the flag from the owner's **live** Clerk metadata (`c.var.clerk.users.getUser(userId)`), for every token type — it no longer reads `sessionClaims`, so the check is independent of the JWT template (a per-request Clerk API call is the tradeoff). Interactive surfaces (web `isExperimental`, the VS Code extension's `hasCloudAccess`) still read the claim off the session token, so those *do* need `early_access`/`internal` in the JWT template even though the worker doesn't.
 - `service()` — first-party service-to-service auth (no Clerk session): constant-time checks `SERVICE_TOKEN_HEADER` against `WORKER_SERVICE_TOKEN`. Used by `/vault/lock` and `/vault/unlock`, which billing webhooks call. Authenticates the *caller*; the subject `userId` is in the request body — treat the token as high-value.
 - Routes with neither gate (e.g. `/drop`) work anonymously; if a caller *is* authenticated, `clerkAuth()` still resolves so the route can read identity opportunistically
 
@@ -88,7 +88,7 @@ worker/
 
 ### Vaults — Turso
 - Provisioning + lifecycle live in `shared/lib/turso/` (`createVaultUtils`) — see `shared/lib/turso/CLAUDE.md`. The former `worker/src/lib/vault.ts` was collapsed into it.
-- `vault.ts` router: create/tokens/get are `restricted()`/`authenticated()` (early-access/internal, per-user Clerk claim; `/vault/tokens` also allows `DEADROP_API_KEY` via `allowApiKey: true`, for CI/`inject`); `lock`/`unlock` are `service()`-gated for billing webhooks
+- `vault.ts` router: create/tokens layer `authenticated({ allowApiKey: true })` + `restricted()`; get is `authenticated({ allowApiKey: true })` alone; delete is `authenticated()` + `restricted()`. API keys (`DEADROP_API_KEY`) are accepted on create/tokens/get for CI/`inject`; `lock`/`unlock` are `service()`-gated for billing webhooks
 - Cancel-on-billing fans out over **all** of a user's vaults via `listVaults(<hash13>)`; org-payer cancellations are a known gap (vaults are named per user, not per org)
 
 ### Billing/plans (`src/lib/billing.ts`)


### PR DESCRIPTION
## Summary
Post-publish polish for the freshly-shipped VS Code extension plus a docs hydration pass. The vault row action buttons were rendering literal `\uXXXX` text instead of icons; that's fixed, along with a debug leak, and the docs are reconciled against everything shipped in the 0.1.3 / worker-auth-refactor batch.

## Changes

### VS Code extension fixes
- **Vault row icons** (739f85b): bare unicode escapes in JSX text nodes render literally — wrapped them in expressions so the copy/rename/save/cancel glyphs display. Ships as `deadrop-vsc` patch (0.1.4) via changeset.
- **Debug leak** (4990724): removed a `console.log` that dumped the full decoded session JWT in `hasCloudAccess`.

### Docs hydration (5d5bd2f)
Reconciled docs against the recent batch (vsix packaging, worker auth refactor, `deadrop update`):
- `worker/CLAUDE.md` — vault routes table + auth-gates section rewritten for the layered `authenticated()` + `restricted()` design (`restricted()` now does a live `getUser()` lookup, no longer reads `sessionClaims`)
- `vscode-extension/CLAUDE.md` — native libsql packaging (`stage-native.js`), esbuild externals, CI-automated marketplace release
- `web/pages/docs/**` — documented the previously-undocumented `deadrop update` command; corrected the VS Code extension vault story (full editor, local + cloud) across features/vscode/faqs

Full compliance audit: all 20 CLI commands, 7 vscode commands, worker routes, and roadmap statuses verified against code. The CLI keychain security claim was verified true against `cli/lib/auth/cache.ts`.

## Testing
- [x] `deadrop-vsc` type-checks clean (views tsc)
- [x] Icon fix verified against the 8 affected buttons
- [x] Docs audit cross-referenced against actual command registration + code, not PR titles
- [ ] On merge: `deadrop-vsc@0.1.4` publishes (icon fix), worker auto-deploys, `worker@1.2.0` version PR opens from the already-landed auth changeset