### PR TITLE
ci: retry flaky e2e, auto-tag desktop releases, fix desktop Clerk creds

### DIFF
--- a/.changeset/tag-desktop-releases.md
+++ b/.changeset/tag-desktop-releases.md
@@ -1,0 +1,5 @@
+---
+"desktop": patch
+---
+
+Release CI now auto-tags desktop releases on publish instead of requiring a manual `deadrop-desktop@*` tag push, and desktop CI/publish builds use prod Clerk credentials instead of placeholders.

--- a/.github/workflows/desktop_ci_workflow.yml
+++ b/.github/workflows/desktop_ci_workflow.yml
@@ -38,17 +38,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Frontend build (Vite), same secrets/vars the other CI jobs already
-      # use (cli_e2e_workflow.yml, web_ci_workflow.yml) — just VITE_-prefixed
-      # so Vite bakes them into the desktop bundle.
+      # Prod secrets only (never dev `vars.*`) — mixing dev Clerk creds with the prod Worker breaks auth.
       - name: Build desktop frontend
         env:
           VITE_DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
           VITE_PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
           VITE_TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
           VITE_TURN_PWD: ${{ secrets.TURN_PWD }}
-          VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
-          VITE_WEB_URL: ${{ vars.DEADROP_APP_URL }}
+          VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
+          VITE_WEB_URL: ${{ secrets.DEADROP_APP_URL }}
         run: pnpm -F desktop build
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/desktop_publish_workflow.yml
+++ b/.github/workflows/desktop_publish_workflow.yml
@@ -86,14 +86,13 @@ jobs:
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Baked into the frontend at build time (Vite) — same
-          # secrets/vars desktop_ci_workflow.yml validates against.
+          # Prod secrets only (never dev `vars.*`) — mixing dev Clerk creds with the prod Worker breaks auth.
           VITE_DEADROP_API_URL: ${{ secrets.DEADROP_API_URL }}
           VITE_PEER_SERVER_URL: ${{ secrets.PEER_SERVER_URL }}
           VITE_TURN_USERNAME: ${{ secrets.TURN_USERNAME }}
           VITE_TURN_PWD: ${{ secrets.TURN_PWD }}
-          VITE_CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
-          VITE_WEB_URL: ${{ vars.DEADROP_APP_URL }}
+          VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
+          VITE_WEB_URL: ${{ secrets.DEADROP_APP_URL }}
         with:
           projectPath: desktop
           tagName: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,19 @@ jobs:
           done
           echo "Dispatching CLI binary build for $tag"
           gh workflow run cli_publish_workflow.yml --ref "$tag"
+      - name: Trigger desktop release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(jq -r .version desktop/package.json)
+          tag="deadrop-desktop@${version}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "$tag already exists, skipping (desktop version unchanged this release)"
+            exit 0
+          fi
+          git tag "$tag"
+          git push origin "refs/tags/$tag"
       - name: Restore cli/package.json name
         if: always()
         run: git checkout -- cli/package.json

--- a/tests/vitest.e2e.config.mts
+++ b/tests/vitest.e2e.config.mts
@@ -13,6 +13,9 @@ export default defineConfig({
     setupFiles: ['dotenv/config'],
     testTimeout: 90_000,
     hookTimeout: 30_000,
+    // CI has needed manual reruns for this suite; retry flaky live-deployment
+    // failures in-process before requiring a human to re-trigger the job.
+    retry: 2,
     // One flow at a time: real browsers + WebRTC peers are resource-heavy.
     fileParallelism: false,
     pool: 'forks',


### PR DESCRIPTION
## Summary

Three small CI/release fixes: retries for the flaky cross-platform e2e suite, automated tagging so desktop releases no longer require a manual tag push, and a fix for desktop CI/publish builds using the wrong Clerk credentials.

## Changes

- **e2e retries** (b76e276): `tests/vitest.e2e.config.mts` now sets `retry: 2` — this suite hits a live deployment + real WebRTC peers and has needed manual GitHub Actions reruns; retrying flaky assertions in-process avoids the manual re-trigger.
- **Desktop release auto-tagging** (7465c1c): new "Trigger desktop release" step in `.github/workflows/release.yml`, mirroring the existing CLI binary release step but adapted for `desktop/`'s `"private": true` package (changesets' `publishedPackages` output never includes it, since it's never published to npm). Reads the version from `desktop/package.json`, tags `deadrop-desktop@<version>`, and pushes — idempotent via a `git ls-remote` existence check, since desktop's version doesn't bump on every release. `desktop_publish_workflow.yml` already listens for `deadrop-desktop@*` tag pushes, so no changes needed there.
- **Desktop Clerk creds fix** (3263dce): `desktop_ci_workflow.yml` and `desktop_publish_workflow.yml` now use prod Clerk credentials instead of placeholders, matching the other CI/publish workflows.

## Testing

- [x] YAML-validated the new release.yml step
- [ ] Desktop auto-tag step unverified against a real release run (next release will exercise it)