### PR TITLE
fix(release): trigger desktop tag on hasChangesets, not published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,11 @@ jobs:
           echo "Dispatching CLI binary build for $tag"
           gh workflow run cli_publish_workflow.yml --ref "$tag"
       - name: Trigger desktop release
-        if: steps.changesets.outputs.published == 'true'
+        # Not `published == 'true'`: that only reflects an actual npm publish,
+        # and desktop is private (never published to npm), so a desktop-only
+        # release would leave it 'false' forever. hasChangesets is 'false' on
+        # the real post-merge run and 'true' on the version-PR-opening run.
+        if: steps.changesets.outputs.hasChangesets == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Fixes the desktop auto-tag step added in #142: it never fired for #143's release because it gated on `published == 'true'`, which only reflects an actual `npm publish`. Desktop is `private` and never publishes to npm, so a desktop-only changeset leaves `published` false forever even on the real post-merge release run.

## Changes

- `.github/workflows/release.yml`: "Trigger desktop release" now gates on `hasChangesets == 'false'` instead — that output is `false` specifically on the real post-merge/publish run and `true` on the version-PR-opening run, independent of whether anything actually hit npm.
- Manually pushed `deadrop-desktop@0.2.1` (mirroring exactly what the fixed step does) against current `main` so this release actually completes instead of waiting for the next changeset — confirmed via `desktop_publish_workflow.yml` run 31145444749.

## Testing

- [x] Confirmed root cause in run 31144878147 logs: `hasChangesets` correctly reflects publish-mode vs version-PR-mode, `published` does not for private-only releases
- [x] Manual tag push confirmed to trigger `desktop_publish_workflow.yml` as expected
- [ ] Next real release (with an npm-publishable package alongside desktop) will exercise the fixed step end-to-end automatically