### PR TITLE
feat(desktop): vault init prompt + import existing vaults

### DIFF
--- a/.changeset/desktop-navbar-spacing-polish.md
+++ b/.changeset/desktop-navbar-spacing-polish.md
@@ -1,0 +1,5 @@
+---
+'desktop': patch
+---
+
+Bumped up the size of the navbar title, logo, nav links, and avatar for better legibility, and fixed inconsistent vertical spacing on the Drop/Grab pages so they now match Home/Vault.

--- a/.changeset/vault-config-persistence-and-global-fallback.md
+++ b/.changeset/vault-config-persistence-and-global-fallback.md
@@ -1,0 +1,6 @@
+---
+'desktop': patch
+'cli': minor
+---
+
+Fixed a bug where the desktop app's vault config silently failed to save, so vaults never survived an app restart. The CLI now also falls back to the same shared vault config (in the OS app-data directory) whenever it's run outside a project with its own `.deadroprc` — so a vault created in the desktop app is immediately usable from the CLI, and vice versa, with no import step needed.

--- a/.changeset/vault-init-prompt-and-import.md
+++ b/.changeset/vault-init-prompt-and-import.md
@@ -1,0 +1,5 @@
+---
+'desktop': patch
+---
+
+The vault page no longer silently creates a `default` vault on first visit — it now asks before setting one up. You can also import an existing vault created by the `deadrop` CLI or the VS Code extension (via its project-level `.deadroprc`) into the desktop app instead of starting from scratch.

--- a/cli/lib/config.ts
+++ b/cli/lib/config.ts
@@ -7,6 +7,10 @@ import { extname } from 'path';
 import { parse, stringify } from 'yaml';
 import { displayWelcomeMessage, logError, logInfo } from './log';
 import { initConfig as baseInitConfig } from '@shared/lib/vault';
+import {
+  globalConfigExists,
+  globalConfigPath,
+} from './global-config';
 
 type CustomConfigResult = Omit<
   NonNullable<CosmiconfigResult>,
@@ -19,15 +23,20 @@ export const loadConfig = async (): Promise<CustomConfigResult> => {
   const { search } = cosmiconfig('deadrop');
 
   const configFile = await search();
+  if (configFile) return configFile;
 
-  if (!configFile) {
-    logError(
-      'No config found, please run `deadrop init` to get started.',
-    );
-    process.exit(1);
+  // No project-scoped .deadroprc found walking up from cwd — fall back to
+  // the global config shared with the desktop app (same app-data dir,
+  // see lib/global-config.ts), rather than requiring every directory to
+  // have its own vault.
+  if (globalConfigExists()) {
+    const filepath = globalConfigPath();
+    const raw = await readFile(filepath, 'utf-8');
+    return { config: parse(raw) as DeadropConfig, filepath, isEmpty: false };
   }
 
-  return configFile;
+  logError('No config found, please run `deadrop init` to get started.');
+  process.exit(1);
 };
 
 export const loadConfigFromPath = async (

--- a/cli/lib/global-config.ts
+++ b/cli/lib/global-config.ts
@@ -1,0 +1,32 @@
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { APP_IDENTIFIER, CONFIG_FILE_NAME } from '@shared/lib/constants';
+
+// Matches Tauri's app_data_dir() resolution for the desktop app's
+// identifier, so CLI and desktop fall back to the same shared, global
+// vault config when no project-scoped .deadroprc is found.
+export const globalConfigDir = (): string => {
+  const home = homedir();
+
+  switch (process.platform) {
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', APP_IDENTIFIER);
+    case 'win32':
+      return join(
+        process.env.APPDATA ?? join(home, 'AppData', 'Roaming'),
+        APP_IDENTIFIER,
+      );
+    default:
+      return join(
+        process.env.XDG_DATA_HOME ?? join(home, '.local', 'share'),
+        APP_IDENTIFIER,
+      );
+  }
+};
+
+export const globalConfigPath = (): string =>
+  join(globalConfigDir(), CONFIG_FILE_NAME);
+
+export const globalConfigExists = (): boolean =>
+  existsSync(globalConfigPath());

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -21,6 +21,7 @@
     "@mantine/notifications": "^8",
     "@tabler/icons-react": "^3",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-http": "^2.5.9",
     "@tauri-apps/plugin-opener": "^2",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -930,6 +930,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-opener",
@@ -3820,6 +3821,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,6 +4782,24 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.19",
+ "url",
 ]
 
 [[package]]
@@ -6090,6 +6133,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6121,11 +6173,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6159,6 +6228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6169,6 +6244,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6183,10 +6264,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6201,6 +6294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6211,6 +6310,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6225,6 +6330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6235,6 +6346,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -31,4 +31,5 @@ tauri-plugin-http = { version = "2.5.9", features = ["unsafe-headers"] }
 libsql = { version = "0.9.30", features = ["remote", "replication"] }
 tokio = { version = "1.53.1", features = ["time"] }
 tauri-plugin-fs = "2.5.1"
+tauri-plugin-dialog = "2"
 

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "dialog:allow-open",
     {
       "identifier": "http:default",
       "allow": [

--- a/desktop/src-tauri/src/config_import.rs
+++ b/desktop/src-tauri/src/config_import.rs
@@ -1,0 +1,9 @@
+// Reads an arbitrary-path .deadroprc chosen via the file picker (a CLI/
+// vscode-extension project vault config). Not routed through the fs plugin
+// (its scope is pinned to $APPDATA — see capabilities/default.json) since
+// vault_store.rs already establishes the pattern of app commands opening
+// user-chosen absolute paths directly.
+#[tauri::command]
+pub fn read_external_text_file(path: String) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|e| e.to_string())
+}

--- a/desktop/src-tauri/src/config_import.rs
+++ b/desktop/src-tauri/src/config_import.rs
@@ -7,3 +7,33 @@
 pub fn read_external_text_file(path: String) -> Result<String, String> {
     std::fs::read_to_string(path).map_err(|e| e.to_string())
 }
+
+fn app_config_path(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+    use tauri::Manager;
+    let dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(dir.join(".deadroprc"))
+}
+
+// This app's own `.deadroprc` (in the Tauri app-data dir) went through
+// `@tauri-apps/plugin-fs` originally, but writes silently no-op'd there —
+// the `$APPDATA/**` capability scope pattern doesn't reliably match a file
+// directly at $APPDATA's root, only nested paths. Reading/writing it as a
+// plain Rust command sidesteps that scope matching entirely, same as
+// `read_external_text_file` above and vault_store.rs's DB access.
+#[tauri::command]
+pub fn read_app_vault_config(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let path = app_config_path(&app)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    std::fs::read_to_string(path).map(Some).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn write_app_vault_config(app: tauri::AppHandle, contents: String) -> Result<(), String> {
+    let path = app_config_path(&app)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(path, contents).map_err(|e| e.to_string())
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ mod config_import;
 mod keychain_store;
 mod vault_store;
 
-use config_import::read_external_text_file;
+use config_import::{read_app_vault_config, read_external_text_file, write_app_vault_config};
 use keychain_store::{clear_auth_token, get_auth_token, set_auth_token};
 use vault_store::{
     vault_add_secret, vault_delete_secret, vault_ensure_schema, vault_get_encrypted_secret,
@@ -35,6 +35,8 @@ pub fn run() {
             vault_rename_secret,
             vault_delete_secret,
             read_external_text_file,
+            read_app_vault_config,
+            write_app_vault_config,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
+mod config_import;
 mod keychain_store;
 mod vault_store;
 
+use config_import::read_external_text_file;
 use keychain_store::{clear_auth_token, get_auth_token, set_auth_token};
 use vault_store::{
     vault_add_secret, vault_delete_secret, vault_ensure_schema, vault_get_encrypted_secret,
@@ -19,6 +21,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             greet,
             get_auth_token,
@@ -31,6 +34,7 @@ pub fn run() {
             vault_update_secret,
             vault_rename_secret,
             vault_delete_secret,
+            read_external_text_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/src/components/MainWrapper.tsx
+++ b/desktop/src/components/MainWrapper.tsx
@@ -1,0 +1,16 @@
+import type { ContainerProps } from '@mantine/core';
+import type { ReactNode } from 'react';
+import { MainWrapper as SharedMainWrapper } from '@shared/components';
+
+// Desktop-specific default: every route (Home/Drop/Grab/Vault) wants the
+// same `py="xl"` vertical padding, so bake it in here rather than making
+// every caller repeat it — kept out of shared/'s MainWrapper since that's
+// consumed cross-platform and shouldn't carry a desktop-only opinion.
+export const MainWrapper = ({
+  children,
+  ...rest
+}: { children: ReactNode } & ContainerProps) => (
+  <SharedMainWrapper py={'xl'} {...rest}>
+    {children}
+  </SharedMainWrapper>
+);

--- a/desktop/src/hooks/use-vault.tsx
+++ b/desktop/src/hooks/use-vault.tsx
@@ -7,7 +7,7 @@ import { isExperimental } from '../lib/billing';
 import { useApiHeaders } from '../lib/api-headers';
 import {
   createNamedVault,
-  loadOrBootstrapVaultConfig,
+  loadVaultConfig,
   saveVaultConfig,
 } from '../lib/vault-config';
 import { deleteCloudVault, provisionCloudVault } from '../lib/vault-cloud';
@@ -49,7 +49,7 @@ export const useVault = () => {
   useEffect(() => {
     (async () => {
       try {
-        setConfig(await loadOrBootstrapVaultConfig());
+        setConfig(await loadVaultConfig());
       } catch (err) {
         setError((err as Error).message);
       } finally {
@@ -100,7 +100,6 @@ export const useVault = () => {
 
   const createVault = (name: string, cloud: boolean) =>
     withBusy(async () => {
-      if (!config) return;
       const vaultConfig = await createNamedVault(name);
 
       if (cloud) {
@@ -112,7 +111,7 @@ export const useVault = () => {
 
       const next: DeadropConfig = {
         active_vault: { name, environment: 'development' },
-        vaults: { ...config.vaults, [name]: vaultConfig },
+        vaults: { ...config?.vaults, [name]: vaultConfig },
       };
       setConfig(next);
       await saveVaultConfig(next);

--- a/desktop/src/hooks/use-vault.tsx
+++ b/desktop/src/hooks/use-vault.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@clerk/react';
+import { showNotification } from '@mantine/notifications';
 import { initEnvKey } from '@shared/lib/vault';
 import { unwrapSecret, wrapSecret } from '@shared/lib/secrets';
 import type { DeadropConfig } from '@shared/types/config';
@@ -8,6 +9,7 @@ import { useApiHeaders } from '../lib/api-headers';
 import {
   createNamedVault,
   loadVaultConfig,
+  pickExternalVaultConfig,
   saveVaultConfig,
 } from '../lib/vault-config';
 import { deleteCloudVault, provisionCloudVault } from '../lib/vault-cloud';
@@ -115,6 +117,46 @@ export const useVault = () => {
       };
       setConfig(next);
       await saveVaultConfig(next);
+    });
+
+  // Links vaults from a project-scoped `.deadroprc` (CLI `deadrop init` /
+  // `vault create`, or vscode-extension) into this config, keyed by name.
+  // The DB `location` stays wherever the project put it — desktop just
+  // starts tracking it alongside vaults created in-app.
+  const importVault = () =>
+    withBusy(async () => {
+      const imported = await pickExternalVaultConfig();
+      if (!imported) return;
+
+      const existingNames = new Set(Object.keys(config?.vaults ?? {}));
+      const nextVaults = { ...config?.vaults };
+      const importedNames: string[] = [];
+
+      for (const [name, vaultConfig] of Object.entries(imported.vaults)) {
+        let finalName = name;
+        let suffix = 2;
+        while (existingNames.has(finalName)) {
+          finalName = `${name}-${suffix++}`;
+        }
+        existingNames.add(finalName);
+        nextVaults[finalName] = vaultConfig;
+        importedNames.push(finalName);
+      }
+
+      const next: DeadropConfig = {
+        active_vault: config?.active_vault ?? {
+          name: importedNames[0],
+          environment: 'development',
+        },
+        vaults: nextVaults,
+      };
+      setConfig(next);
+      await saveVaultConfig(next);
+
+      showNotification({
+        message: `Imported vault${importedNames.length > 1 ? 's' : ''}: ${importedNames.join(', ')}`,
+        color: 'teal',
+      });
     });
 
   const createEnvironment = (name: string) =>
@@ -236,6 +278,7 @@ export const useVault = () => {
     switchVault,
     switchEnv,
     createVault,
+    importVault,
     createEnvironment,
     toggleCloudSync,
     addSecret,

--- a/desktop/src/layouts/RootLayout.tsx
+++ b/desktop/src/layouts/RootLayout.tsx
@@ -20,7 +20,7 @@ const NavLink = ({
       c={active ? 'gray.0' : 'dimmed'}
       fw={active ? 600 : 500}
       underline={'never'}
-      size={'sm'}
+      size={'md'}
     >
       {children}
     </Anchor>
@@ -31,7 +31,7 @@ export const RootLayout = () => {
   const { isSignedIn } = useUser();
 
   return (
-    <AppShell header={{ height: 56 }} padding={'md'}>
+    <AppShell header={{ height: 64 }} padding={'md'}>
       <AppShell.Header>
         <Group h={'100%'} px={'md'} justify={'space-between'}>
           <Group gap={'xl'}>
@@ -40,17 +40,17 @@ export const RootLayout = () => {
               to={'/'}
               underline={'never'}
               display={'flex'}
-              style={{ alignItems: 'center', gap: 8 }}
+              style={{ alignItems: 'center', gap: 10 }}
             >
               <img
                 src={'/handshake.svg'}
                 alt={''}
-                width={34}
-                height={34}
+                width={40}
+                height={40}
               />
               <Text
-                fw={600}
-                size={'sm'}
+                fw={700}
+                size={'lg'}
                 c={'gray.2'}
                 style={{ letterSpacing: 0.2 }}
               >
@@ -65,10 +65,14 @@ export const RootLayout = () => {
           </Group>
           <Group>
             {isSignedIn ? (
-              <UserButton />
+              <UserButton
+                appearance={{
+                  elements: { avatarBox: { width: 42, height: 42 } },
+                }}
+              />
             ) : (
               <SignInButton mode={'modal'}>
-                <Button size={'xs'} variant={'light'}>
+                <Button size={'sm'} variant={'light'}>
                   Sign in
                 </Button>
               </SignInButton>

--- a/desktop/src/lib/vault-config.ts
+++ b/desktop/src/lib/vault-config.ts
@@ -7,7 +7,7 @@ import {
 } from '@tauri-apps/plugin-fs';
 import { appDataDir, join } from '@tauri-apps/api/path';
 import { parse, stringify } from 'yaml';
-import { initConfig, vault as buildVaultConfig } from '@shared/lib/vault';
+import { vault as buildVaultConfig } from '@shared/lib/vault';
 import type { DeadropConfig, VaultDBConfig } from '@shared/types/config';
 
 // Same `.deadroprc` YAML pattern CLI (lib/config.ts) and vscode-extension
@@ -42,24 +42,6 @@ async function ensureVaultsDir(): Promise<void> {
     baseDir: BaseDirectory.AppData,
     recursive: true,
   });
-}
-
-async function defaultVaultPath(): Promise<string> {
-  await ensureVaultsDir();
-  const dir = await appDataDir();
-  return join(dir, 'vaults', 'default.db');
-}
-
-// Mirrors cli/actions/init.ts + shared/lib/vault.ts's initConfig(): first
-// launch with no config bootstraps one vault named `default`, no manual
-// "create your first vault" step required.
-export async function loadOrBootstrapVaultConfig(): Promise<DeadropConfig> {
-  const existing = await loadVaultConfig();
-  if (existing) return existing;
-
-  const config = await initConfig(await defaultVaultPath());
-  await saveVaultConfig(config);
-  return config;
 }
 
 export async function vaultPathForName(name: string): Promise<string> {

--- a/desktop/src/lib/vault-config.ts
+++ b/desktop/src/lib/vault-config.ts
@@ -6,6 +6,8 @@ import {
   writeTextFile,
 } from '@tauri-apps/plugin-fs';
 import { appDataDir, join } from '@tauri-apps/api/path';
+import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
 import { parse, stringify } from 'yaml';
 import { vault as buildVaultConfig } from '@shared/lib/vault';
 import type { DeadropConfig, VaultDBConfig } from '@shared/types/config';
@@ -54,4 +56,25 @@ export async function createNamedVault(
   name: string,
 ): Promise<VaultDBConfig> {
   return buildVaultConfig(await vaultPathForName(name));
+}
+
+// Lets a project-scoped `.deadroprc` (written by `deadrop init`/CLI `vault
+// create`, or vscode-extension) be linked into the desktop app's config.
+// Vault `location` paths in those files are always absolute (resolved
+// against the project's cwd at write time), so they can be opened as-is by
+// vault_store.rs without copying the DB file — desktop stays the single
+// source of truth for *which* vaults are known, the DB itself stays put.
+export async function pickExternalVaultConfig(): Promise<DeadropConfig | null> {
+  const path = await openFileDialog({
+    multiple: false,
+    filters: [{ name: 'deadrop config', extensions: ['deadroprc', 'yaml', 'yml'] }],
+  });
+  if (!path) return null;
+
+  const contents = await invoke<string>('read_external_text_file', { path });
+  const parsed = parse(contents) as DeadropConfig;
+  if (!parsed?.vaults || !parsed?.active_vault) {
+    throw new Error(`Not a valid .deadroprc: ${path}`);
+  }
+  return parsed;
 }

--- a/desktop/src/lib/vault-config.ts
+++ b/desktop/src/lib/vault-config.ts
@@ -1,10 +1,4 @@
-import {
-  BaseDirectory,
-  exists,
-  mkdir,
-  readTextFile,
-  writeTextFile,
-} from '@tauri-apps/plugin-fs';
+import { mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
 import { appDataDir, join } from '@tauri-apps/api/path';
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
@@ -16,27 +10,23 @@ import type { DeadropConfig, VaultDBConfig } from '@shared/types/config';
 // (src/lib/config.ts) already use, not a JSON store — same DeadropConfig
 // shape, just a different root directory (Tauri's app data dir; desktop has
 // no "workspace root"/cwd the way CLI/vscode-extension do).
-const CONFIG_FILE_NAME = '.deadroprc';
-
+//
+// Read/write goes through Rust commands (read_app_vault_config /
+// write_app_vault_config), not `@tauri-apps/plugin-fs` — the fs plugin's
+// `$APPDATA/**` capability scope didn't reliably match a file directly at
+// $APPDATA's root, so writes were silently no-op'ing. Custom commands
+// bypass that scope entirely, same pattern as read_external_text_file and
+// vault_store.rs's DB access.
 export async function loadVaultConfig(): Promise<DeadropConfig | null> {
-  const fileExists = await exists(CONFIG_FILE_NAME, {
-    baseDir: BaseDirectory.AppData,
-  });
-  if (!fileExists) return null;
-
-  const contents = await readTextFile(CONFIG_FILE_NAME, {
-    baseDir: BaseDirectory.AppData,
-  });
+  const contents = await invoke<string | null>('read_app_vault_config');
+  if (!contents) return null;
   return parse(contents) as DeadropConfig;
 }
 
 export async function saveVaultConfig(
   config: DeadropConfig,
 ): Promise<void> {
-  await mkdir('.', { baseDir: BaseDirectory.AppData, recursive: true });
-  await writeTextFile(CONFIG_FILE_NAME, stringify(config), {
-    baseDir: BaseDirectory.AppData,
-  });
+  await invoke('write_app_vault_config', { contents: stringify(config) });
 }
 
 async function ensureVaultsDir(): Promise<void> {

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -138,7 +138,7 @@ const AppWithClerk = () => {
     >
       <MantineProvider
         defaultColorScheme={'dark'}
-        theme={{ primaryColor: 'blue' }}
+        theme={{ primaryColor: 'blue', scale: 1.1 }}
       >
         <Notifications />
         <RouterProvider router={router} />

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -1,5 +1,13 @@
 import type { Clerk } from '@clerk/clerk-js';
-import { StrictMode, Suspense, use, useEffect, useRef } from 'react';
+import {
+  Component,
+  StrictMode,
+  Suspense,
+  use,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
 import ReactDOM from 'react-dom/client';
 import { ClerkProvider } from '@clerk/react';
 import { invoke } from '@tauri-apps/api/core';
@@ -38,6 +46,77 @@ const useClearSharedTokenOnSignOut = (clerk: Clerk) => {
   }, [clerk]);
 };
 
+// TEMPORARY diagnostic: `Suspense fallback={null}` hides Clerk init
+// failures as a permanent blank screen with nothing in any log. This
+// surfaces the actual error on-screen instead. Remove once the boot
+// white-screen issue is root-caused.
+class BootErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: unknown }
+> {
+  state = { error: undefined as unknown };
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error !== undefined) {
+      return (
+        <pre style={{ padding: 24, whiteSpace: 'pre-wrap', color: 'red' }}>
+          {String(
+            this.state.error instanceof Error
+              ? (this.state.error.stack ?? this.state.error.message)
+              : this.state.error,
+          )}
+        </pre>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const BootLoading = () => (
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 16,
+      height: '100vh',
+      width: '100vw',
+      background: '#1a1b1e',
+    }}
+  >
+    <img
+      src={'/handshake.svg'}
+      alt={'deadrop'}
+      width={48}
+      height={48}
+      style={{ animation: 'deadrop-pulse 1.6s ease-in-out infinite' }}
+    />
+    <span
+      style={{
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif',
+        fontWeight: 600,
+        fontSize: 14,
+        letterSpacing: 0.2,
+        color: '#c1c2c5',
+      }}
+    >
+      deadrop
+    </span>
+    <style>{`
+      @keyframes deadrop-pulse {
+        0%, 100% { opacity: 0.45; transform: scale(0.96); }
+        50% { opacity: 1; transform: scale(1); }
+      }
+    `}</style>
+  </div>
+);
+
 const AppWithClerk = () => {
   const clerk = use(clerkPromise);
   useClearSharedTokenOnSignOut(clerk);
@@ -72,8 +151,10 @@ ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 ).render(
   <StrictMode>
-    <Suspense fallback={null}>
-      <AppWithClerk />
-    </Suspense>
+    <BootErrorBoundary>
+      <Suspense fallback={<BootLoading />}>
+        <AppWithClerk />
+      </Suspense>
+    </BootErrorBoundary>
   </StrictMode>,
 );

--- a/desktop/src/routes/Drop.tsx
+++ b/desktop/src/routes/Drop.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from '@clerk/react';
-import { DropFlow, MainWrapper } from '@shared/components';
+import { DropFlow } from '@shared/components';
+import { MainWrapper } from '../components/MainWrapper';
 import { DropState } from '@shared/lib/constants';
 import { DropProvider, useDropContext } from '../contexts/DropContext';
 import { isExperimental } from '../lib/billing';

--- a/desktop/src/routes/Grab.tsx
+++ b/desktop/src/routes/Grab.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Button, Stack, Text, TextInput } from '@mantine/core';
-import { GrabFlow, MainWrapper } from '@shared/components';
+import { GrabFlow } from '@shared/components';
+import { MainWrapper } from '../components/MainWrapper';
 import { GrabState } from '@shared/lib/constants';
 import { GrabProvider, useGrabContext } from '../contexts/GrabContext';
 import { downloadFile } from '../lib/files';

--- a/desktop/src/routes/Home.tsx
+++ b/desktop/src/routes/Home.tsx
@@ -15,7 +15,7 @@ import {
   IconDownload,
   IconLock,
 } from '@tabler/icons-react';
-import { MainWrapper } from '@shared/components';
+import { MainWrapper } from '../components/MainWrapper';
 
 // Desktop home is a hub/dashboard for engaged users — quick actions +
 // account/vault status, not a marketing landing page.
@@ -62,7 +62,7 @@ export const HomePage = () => {
     : 'Welcome back';
 
   return (
-    <MainWrapper py={'xl'}>
+    <MainWrapper>
       <Stack gap={'xl'} w={'100%'}>
         <div>
           <Title order={2} mb={4}>

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -22,7 +22,7 @@ import {
   IconFileImport,
   IconPlus,
 } from '@tabler/icons-react';
-import { MainWrapper } from '@shared/components';
+import { MainWrapper } from '../components/MainWrapper';
 import { useVault } from '../hooks/use-vault';
 import { AddSecretForm } from '../components/vault/AddSecretForm';
 import { CreateVaultModal } from '../components/vault/CreateVaultModal';
@@ -85,7 +85,7 @@ export const VaultPage = () => {
 
   if (!vault.config) {
     return (
-      <MainWrapper py={'xl'}>
+      <MainWrapper>
         <Center mih={'50vh'}>
           <Stack gap={'md'} align={'center'}>
             {vault.error && (
@@ -135,7 +135,7 @@ export const VaultPage = () => {
   );
 
   return (
-    <MainWrapper py={'xl'}>
+    <MainWrapper>
       <Stack gap={'lg'} w={'100%'}>
         <Group justify={'space-between'}>
           <Group gap={'sm'}>

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -19,6 +19,7 @@ import {
   IconChevronDown,
   IconCloud,
   IconCloudOff,
+  IconFileImport,
   IconPlus,
 } from '@tabler/icons-react';
 import { MainWrapper } from '@shared/components';
@@ -87,15 +88,34 @@ export const VaultPage = () => {
       <MainWrapper py={'xl'}>
         <Center mih={'50vh'}>
           <Stack gap={'md'} align={'center'}>
+            {vault.error && (
+              <Alert
+                color={'red'}
+                icon={<IconAlertCircle size={16} />}
+                onClose={() => {}}
+              >
+                {vault.error}
+              </Alert>
+            )}
             <Text size={'sm'} c={'dimmed'}>
               You don&apos;t have a vault yet.
             </Text>
-            <Button
-              leftSection={<IconPlus size={14} />}
-              onClick={() => setCreateModalOpen(true)}
-            >
-              Create your vault
-            </Button>
+            <Group gap={'sm'}>
+              <Button
+                leftSection={<IconPlus size={14} />}
+                onClick={() => setCreateModalOpen(true)}
+              >
+                Create your vault
+              </Button>
+              <Button
+                variant={'default'}
+                leftSection={<IconFileImport size={14} />}
+                loading={vault.busy}
+                onClick={() => void vault.importVault()}
+              >
+                Import existing vault
+              </Button>
+            </Group>
           </Stack>
         </Center>
         <CreateVaultModal
@@ -145,6 +165,12 @@ export const VaultPage = () => {
                   onClick={() => setCreateModalOpen(true)}
                 >
                   New vault
+                </Menu.Item>
+                <Menu.Item
+                  leftSection={<IconFileImport size={14} />}
+                  onClick={() => void vault.importVault()}
+                >
+                  Import vault
                 </Menu.Item>
               </Menu.Dropdown>
             </Menu>

--- a/desktop/src/routes/Vault.tsx
+++ b/desktop/src/routes/Vault.tsx
@@ -82,6 +82,33 @@ export const VaultPage = () => {
     );
   }
 
+  if (!vault.config) {
+    return (
+      <MainWrapper py={'xl'}>
+        <Center mih={'50vh'}>
+          <Stack gap={'md'} align={'center'}>
+            <Text size={'sm'} c={'dimmed'}>
+              You don&apos;t have a vault yet.
+            </Text>
+            <Button
+              leftSection={<IconPlus size={14} />}
+              onClick={() => setCreateModalOpen(true)}
+            >
+              Create your vault
+            </Button>
+          </Stack>
+        </Center>
+        <CreateVaultModal
+          opened={createModalOpen}
+          onClose={() => setCreateModalOpen(false)}
+          canCloudSync={vault.canCloudSync}
+          busy={vault.busy}
+          onCreate={vault.createVault}
+        />
+      </MainWrapper>
+    );
+  }
+
   const vaultNames = Object.keys(vault.config?.vaults ?? {});
   const filtered = vault.secretNames.filter(
     (s) => s.environment === vault.activeEnv,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2
+        version: 2.7.2
       '@tauri-apps/plugin-fs':
         specifier: ^2.5.1
         version: 2.5.1
@@ -3852,6 +3855,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.2':
+    resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
 
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
@@ -14338,6 +14344,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-dialog@2.7.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-fs@2.5.1':
     dependencies:

--- a/shared/lib/constants.ts
+++ b/shared/lib/constants.ts
@@ -66,6 +66,11 @@ export const CONFIG_FILE_NAME = '.deadroprc';
 
 export const STORAGE_DIR_NAME = '.deadrop';
 
+// Must match `identifier` in desktop/src-tauri/tauri.conf.json — used by
+// the CLI to compute the same OS app-data directory Tauri's
+// app_data_dir() resolves to, so both share one global default config.
+export const APP_IDENTIFIER = 'com.deadrop';
+
 export const DEFAULT_VAULT_NAME = 'default.db';
 
 export const SECRET_VALUE_DELIMITER = ' | ';


### PR DESCRIPTION
## Summary
- Vault page no longer silently auto-creates a `default` vault on first visit — it now shows a "You don't have a vault yet" prompt with a create button, using the same create-vault modal as adding additional vaults.
- Added an "Import vault" flow: pick an existing project-scoped `.deadroprc` (written by `deadrop init`/`vault create` or the vscode-extension) via a native file dialog, and its vaults get merged into the desktop app's config by name (auto-suffixing on name collisions, e.g. `default` -> `default-2`). The vault's DB file stays wherever the project put it — only the config entry is copied, so desktop stays the single source of truth for which vaults it knows about.
- New Rust command `read_external_text_file` reads the picked path directly (bypasses the fs-plugin's `$APPDATA`-only scope, mirroring how `vault_store.rs` already opens arbitrary absolute-path SQLite files).

## Test plan
- [x] `cargo check` in `desktop/src-tauri` — compiles clean
- [x] `pnpm -F desktop typecheck` — no new errors vs main
- [x] Verified a real `deadrop init`-generated `.deadroprc` parses and validates correctly against the import logic
- [x] Local `pnpm desktop:dev` build: confirm "Create your vault" prompt appears on first visit instead of silent auto-create
- [ ] Local build: confirm "Import vault" (empty-state button + switcher menu item) opens a native file picker, and importing a CLI-created `.deadroprc` adds its vault(s) to the switcher with secrets readable
- [ ] Confirm importing a vault whose name collides with an existing one auto-renames (e.g. `default-2`) instead of overwriting