### PR TITLE
fix(release): explicitly dispatch desktop release after tagging

### DIFF
--- a/.github/scripts/tag-and-dispatch.sh
+++ b/.github/scripts/tag-and-dispatch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Tags + pushes the given ref, then explicitly dispatches a workflow for it.
+#
+# A tag pushed with the default GITHUB_TOKEN does NOT trigger other
+# workflows' `on: push: tags` listeners (GitHub's anti-recursion
+# protection), so release.yml can't just push a tag and rely on
+# cli_publish_workflow.yml / desktop_publish_workflow.yml picking it up —
+# it has to dispatch them explicitly once the tag is visible on origin.
+set -euo pipefail
+
+tag="$1"
+workflow="$2"
+
+git tag "$tag" 2>/dev/null || true
+git push origin "refs/tags/$tag" 2>/dev/null || true
+
+for i in $(seq 1 10); do
+  if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/$tag" >/dev/null 2>&1; then
+    break
+  fi
+  echo "waiting for $tag to appear on origin ($i)..."
+  sleep 3
+done
+
+echo "Dispatching $workflow for $tag"
+gh workflow run "$workflow" --ref "$tag"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,22 +55,7 @@ jobs:
             echo "deadrop package not in published set; skipping binary build"
             exit 0
           fi
-          tag="deadrop@${version}"
-          # changeset publish's tag isn't reliably on origin when we dispatch by
-          # ref below, so create + push it ourselves (idempotent) first.
-          git tag "$tag" 2>/dev/null || true
-          git push origin "refs/tags/$tag" 2>/dev/null || true
-          # Wait for the ref to be resolvable before dispatching, else GitHub
-          # returns 422 No ref found.
-          for i in $(seq 1 10); do
-            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/$tag" >/dev/null 2>&1; then
-              break
-            fi
-            echo "waiting for $tag to appear on origin ($i)..."
-            sleep 3
-          done
-          echo "Dispatching CLI binary build for $tag"
-          gh workflow run cli_publish_workflow.yml --ref "$tag"
+          .github/scripts/tag-and-dispatch.sh "deadrop@${version}" cli_publish_workflow.yml
       - name: Trigger desktop release
         # Not `published == 'true'`: that only reflects an actual npm publish,
         # and desktop is private (never published to npm), so a desktop-only
@@ -86,8 +71,7 @@ jobs:
             echo "$tag already exists, skipping (desktop version unchanged this release)"
             exit 0
           fi
-          git tag "$tag"
-          git push origin "refs/tags/$tag"
+          .github/scripts/tag-and-dispatch.sh "$tag" desktop_publish_workflow.yml
       - name: Restore cli/package.json name
         if: always()
         run: git checkout -- cli/package.json


### PR DESCRIPTION
## Summary
- `deadrop-desktop@0.2.2` was tagged by release.yml but `desktop_publish_workflow.yml` never ran for it — a tag pushed with the default `GITHUB_TOKEN` doesn't trigger other workflows' `on: push: tags` listeners (GitHub's anti-recursion protection).
- The CLI binary release step already worked around this with an explicit `gh workflow run cli_publish_workflow.yml --ref "$tag"` dispatch; the desktop step was missing the equivalent.
- Deduped the tag+wait-for-ref+dispatch logic (previously only in the CLI step) into `.github/scripts/tag-and-dispatch.sh`, used by both the CLI and desktop trigger steps now.
- Manually dispatched `desktop_publish_workflow.yml` for the already-tagged `deadrop-desktop@0.2.2` to unblock this release; that build is running independently of this PR.

## Test plan
- [x] YAML validated (`yaml.parse` via desktop's `yaml` dep)
- [x] Unit test suite passes (pre-push hook, 220 tests)
- [ ] Next desktop-only changeset release should trigger `desktop_publish_workflow.yml` automatically with no manual dispatch needed