### PR TITLE
docs hydration + desktop install for Windows/Linux

### DIFF
--- a/.changeset/desktop-install-windows-linux.md
+++ b/.changeset/desktop-install-windows-linux.md
@@ -1,0 +1,5 @@
+---
+'cli': minor
+---
+
+`deadrop desktop install` (and the desktop-update prompt in `deadrop update`) now works on Windows and Linux, not just macOS — silent NSIS install on Windows, an AppImage placed in `~/.local/bin` on Linux. `install-desktop.sh` also gained Linux support; Windows still goes through the CLI for now (no native shell there).

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -45,7 +45,7 @@ deadrop login           # Authenticate with Clerk
 deadrop logout
 deadrop whoami           # Check signed-in identity
 deadrop update           # Update to the latest version (npm or standalone binary); also offers to update desktop if installed
-deadrop desktop install # Install (or update) the deadrop desktop app (macOS only)
+deadrop desktop install # Install (or update) the deadrop desktop app (macOS/Windows/Linux)
 deadrop drop            # Share a secret (drives dropMachine)
 deadrop grab            # Receive a secret (drives grabMachine)
 deadrop inject           # Run a command with vault secrets injected as env vars

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -24,7 +24,8 @@ cli/
 │   ├── auth/       # clerk.ts (getSessionToken(), see Key Patterns) + cache.ts (OS keychain via keytar/Bun.secrets — never plaintext) + the login OAuth loopback server
 │   ├── update/     # Self-update: binary.ts (download+checksum+atomic replace) vs npm.ts (package-manager detection), shared by version.ts/download.ts/checksum.ts
 │   ├── process.ts  # runWithEnv: spawns a child with injected env, forwards signals/exit code
-│   ├── config.ts   # CLI config file (~/.deadrop); loadConfigFromPath for --config
+│   ├── config.ts   # cwd-scoped .deadroprc search (cosmiconfig), falling back to global-config.ts; loadConfigFromPath for --config
+│   ├── global-config.ts # Shared default vault config in the OS app-data dir — mirrors desktop's Tauri app_data_dir() so CLI/desktop see the same vault when no project-scoped config exists
 │   └── ...         # crypto.ts, env.ts, files.ts, peer.ts, log/ — platform-specific I/O, see Key Patterns
 ├── db/             # Drizzle schema (vaults.ts) + migrations/, initialized via init.ts at startup
 ├── scripts/        # esbuild config + npm release lifecycle scripts

--- a/cli/actions/desktop/install.ts
+++ b/cli/actions/desktop/install.ts
@@ -1,17 +1,19 @@
 import {
-  DESKTOP_APP_PATH,
   fetchLatestDesktopRelease,
+  getDesktopInstallLocation,
   getInstalledDesktopVersion,
   installOrUpdateDesktop,
 } from 'lib/update/desktop';
 import { isNewerVersion } from 'lib/update/version';
 import { logError, logInfo } from 'lib/log';
 
+const SUPPORTED_PLATFORMS = ['darwin', 'win32', 'linux'];
+
 export async function desktopInstall(
   options: { force?: boolean } = {},
 ) {
-  if (process.platform !== 'darwin') {
-    logError('deadrop desktop is currently macOS-only.');
+  if (!SUPPORTED_PLATFORMS.includes(process.platform)) {
+    logError(`deadrop desktop is not supported on ${process.platform}.`);
     return process.exit(1);
   }
 
@@ -48,9 +50,16 @@ export async function desktopInstall(
     return process.exit(1);
   }
 
+  const installLocation = getDesktopInstallLocation();
+  const unsignedWarning =
+    process.platform === 'darwin'
+      ? 'Unsigned build — the first launch may show an "unidentified developer" warning; right-click the app and choose Open.'
+      : process.platform === 'win32'
+        ? 'Unsigned build — Windows SmartScreen may warn on first launch; choose "More info" → "Run anyway".'
+        : 'Unsigned build.';
+
   logInfo(
-    `deadrop desktop v${release.version} installed to ${DESKTOP_APP_PATH}\n` +
-      `Unsigned build — the first launch may show an "unidentified developer" warning; right-click the app and choose Open.`,
+    `deadrop desktop v${release.version} installed${installLocation ? ` to ${installLocation}` : ''}\n${unsignedWarning}`,
   );
 
   return process.exit(0);

--- a/cli/actions/update.ts
+++ b/cli/actions/update.ts
@@ -14,8 +14,6 @@ import {
 // succeeded by the time this runs, so a failure here is a warning, not a
 // reason to exit non-zero.
 async function maybeOfferDesktopUpdate() {
-  if (process.platform !== 'darwin') return;
-
   const installedVersion = getInstalledDesktopVersion();
   if (!installedVersion) return;
 

--- a/cli/install-desktop.sh
+++ b/cli/install-desktop.sh
@@ -4,18 +4,29 @@ set -euo pipefail
 REPO="dallen4/deadrop"
 APP_NAME="deadrop.app"
 APP_PATH="/Applications/${APP_NAME}"
+INSTALL_DIR="${DEADROP_INSTALL_DIR:-$HOME/.local/bin}"
+APPIMAGE_PATH="${INSTALL_DIR}/deadrop-desktop.AppImage"
 
-if [ "$(uname -s)" != "Darwin" ]; then
-  echo "deadrop desktop is currently macOS-only." >&2
-  exit 1
-fi
+OS="$(uname -s)"
+case "$OS" in
+  Darwin|Linux) ;;
+  *)
+    # Bash doesn't run natively on Windows (no PowerShell/cmd support) —
+    # `deadrop desktop install` (Node, cross-platform) is the real Windows
+    # install path for now. A native install-desktop.ps1 is a tracked
+    # fast-follow, not built yet.
+    echo "install-desktop.sh doesn't support ${OS}." >&2
+    echo "On Windows, use \`deadrop desktop install\` (npm install -g deadrop, or the CLI installer) or download the build directly: https://github.com/${REPO}/releases" >&2
+    exit 1
+    ;;
+esac
 
 # Finding the right release (deadrop-desktop@* among a releases list shared
-# with the CLI's deadrop@* tags) and then that release's own .dmg/.sha256
-# assets needs real JSON structure, not a flat grep extraction like
-# install.sh does — jq is the standard tool for this.
+# with the CLI's deadrop@* tags) and then that release's own assets needs
+# real JSON structure, not a flat grep extraction like install.sh does —
+# jq is the standard tool for this.
 if ! command -v jq >/dev/null 2>&1; then
-  echo "install-desktop.sh requires jq. Install it with: brew install jq" >&2
+  echo "install-desktop.sh requires jq. Install it with: brew install jq (macOS) or your distro's package manager (Linux)" >&2
   exit 1
 fi
 
@@ -33,11 +44,18 @@ if [ "$RELEASE" = "null" ] || [ -z "$RELEASE" ]; then
 fi
 
 TAG=$(printf '%s' "$RELEASE" | jq -r '.tag_name')
-DMG_URL=$(printf '%s' "$RELEASE" | jq -r '.assets[] | select(.name | endswith(".dmg")) | .browser_download_url' | head -1)
-SHA_URL=$(printf '%s' "$RELEASE" | jq -r '.assets[] | select(.name | endswith(".dmg.sha256")) | .browser_download_url' | head -1)
 
-if [ -z "$DMG_URL" ] || [ -z "$SHA_URL" ]; then
-  echo "Could not find a .dmg (or its checksum) on release ${TAG}" >&2
+if [ "$OS" = "Darwin" ]; then
+  ASSET_EXT="dmg"
+else
+  ASSET_EXT="AppImage"
+fi
+
+ASSET_URL=$(printf '%s' "$RELEASE" | jq -r --arg ext ".$ASSET_EXT" '.assets[] | select(.name | endswith($ext)) | .browser_download_url' | head -1)
+SHA_URL=$(printf '%s' "$RELEASE" | jq -r --arg ext ".$ASSET_EXT.sha256" '.assets[] | select(.name | endswith($ext)) | .browser_download_url' | head -1)
+
+if [ -z "$ASSET_URL" ] || [ -z "$SHA_URL" ]; then
+  echo "Could not find a .${ASSET_EXT} (or its checksum) on release ${TAG}" >&2
   exit 1
 fi
 
@@ -51,17 +69,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
-curl -fsSL --progress-bar "$DMG_URL" -o "$TMP/deadrop.dmg"
-curl -fsSL "$SHA_URL" -o "$TMP/deadrop.dmg.sha256" || {
+ASSET_PATH="$TMP/deadrop.${ASSET_EXT}"
+curl -fsSL --progress-bar "$ASSET_URL" -o "$ASSET_PATH"
+curl -fsSL "$SHA_URL" -o "${ASSET_PATH}.sha256" || {
   echo "Could not download checksum for verification" >&2
   exit 1
 }
 
-EXPECTED=$(awk '{print $1}' "$TMP/deadrop.dmg.sha256")
+EXPECTED=$(awk '{print $1}' "${ASSET_PATH}.sha256")
 if command -v sha256sum >/dev/null 2>&1; then
-  ACTUAL=$(sha256sum "$TMP/deadrop.dmg" | awk '{print $1}')
+  ACTUAL=$(sha256sum "$ASSET_PATH" | awk '{print $1}')
 else
-  ACTUAL=$(shasum -a 256 "$TMP/deadrop.dmg" | awk '{print $1}')
+  ACTUAL=$(shasum -a 256 "$ASSET_PATH" | awk '{print $1}')
 fi
 if [ -z "$EXPECTED" ] || [ "$EXPECTED" != "$ACTUAL" ]; then
   echo "Checksum verification failed (expected ${EXPECTED:-<none>}, got ${ACTUAL})" >&2
@@ -69,20 +88,36 @@ if [ -z "$EXPECTED" ] || [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "Checksum verified."
 
-ATTACH_OUTPUT=$(hdiutil attach "$TMP/deadrop.dmg" -nobrowse)
-MOUNT_POINT=$(printf '%s' "$ATTACH_OUTPUT" | grep -o '/Volumes/[^[:space:]]*' | head -1)
-if [ -z "$MOUNT_POINT" ]; then
-  echo "Could not determine hdiutil mount point" >&2
-  exit 1
+if [ "$OS" = "Darwin" ]; then
+  ATTACH_OUTPUT=$(hdiutil attach "$ASSET_PATH" -nobrowse)
+  MOUNT_POINT=$(printf '%s' "$ATTACH_OUTPUT" | grep -o '/Volumes/[^[:space:]]*' | head -1)
+  if [ -z "$MOUNT_POINT" ]; then
+    echo "Could not determine hdiutil mount point" >&2
+    exit 1
+  fi
+
+  if [ -d "$APP_PATH" ]; then
+    rm -rf "$APP_PATH"
+  fi
+  ditto "${MOUNT_POINT}/${APP_NAME}" "$APP_PATH"
+
+  hdiutil detach "$MOUNT_POINT" -quiet
+  MOUNT_POINT=""
+
+  echo "deadrop desktop ${TAG} installed to ${APP_PATH}"
+  echo "Unsigned build — the first launch may show an \"unidentified developer\" warning; right-click the app and choose Open."
+else
+  # AppImages are self-contained — "installing" is just placing an
+  # executable file, no package manager involved. Same ~/.local/bin
+  # convention install.sh already uses for the CLI binary itself.
+  chmod +x "$ASSET_PATH"
+  mkdir -p "$INSTALL_DIR"
+  mv "$ASSET_PATH" "$APPIMAGE_PATH"
+
+  echo "deadrop desktop ${TAG} installed to ${APPIMAGE_PATH}"
+  echo "Unsigned build."
+
+  if ! printf '%s' "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+    echo "${INSTALL_DIR} is not in your PATH — run it directly: ${APPIMAGE_PATH}"
+  fi
 fi
-
-if [ -d "$APP_PATH" ]; then
-  rm -rf "$APP_PATH"
-fi
-ditto "${MOUNT_POINT}/${APP_NAME}" "$APP_PATH"
-
-hdiutil detach "$MOUNT_POINT" -quiet
-MOUNT_POINT=""
-
-echo "deadrop desktop ${TAG} installed to ${APP_PATH}"
-echo "Unsigned build — the first launch may show an \"unidentified developer\" warning; right-click the app and choose Open."

--- a/cli/lib/update/desktop.ts
+++ b/cli/lib/update/desktop.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from 'child_process';
-import { existsSync, mkdtempSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { GITHUB_RELEASES_URL } from 'lib/constants';
 import { fetchExpectedChecksum, verifyChecksum } from './checksum';
@@ -8,18 +17,32 @@ import { downloadWithProgress } from './download';
 
 export const DESKTOP_APP_PATH = '/Applications/deadrop.app';
 
+const LINUX_INSTALL_DIR =
+  process.env.DEADROP_INSTALL_DIR ?? join(homedir(), '.local', 'bin');
+export const LINUX_APPIMAGE_PATH = join(
+  LINUX_INSTALL_DIR,
+  'deadrop-desktop.AppImage',
+);
+const LINUX_VERSION_FILE = join(
+  LINUX_INSTALL_DIR,
+  '.deadrop-desktop.version',
+);
+
+// Best-effort, unverified against a real Windows install — Tauri's NSIS
+// bundler is assumed to register the uninstall entry under `productName`
+// (tauri.conf.json), matching the default template. Wrapped in try/catch
+// below, so a wrong key name just makes getInstalledDesktopVersion()
+// degrade to "not installed" rather than throwing.
+const WINDOWS_UNINSTALL_KEY =
+  'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\deadrop';
+
 export type DesktopRelease = {
   version: string;
-  dmgUrl: string;
-  dmgSha256Url: string;
+  assetUrl: string;
+  assetSha256Url: string;
 };
 
-// Reads CFBundleShortVersionString via `plutil -extract ... raw` — always
-// present on macOS, handles both binary and XML plist formats (unlike
-// `defaults read`, which has awkward path/domain ambiguity). Treats any
-// failure (not installed, malformed Info.plist) as "not installed" rather
-// than throwing — both call sites want that conservative fallback.
-export function getInstalledDesktopVersion(): string | null {
+function getInstalledDesktopVersionMac(): string | null {
   if (!existsSync(DESKTOP_APP_PATH)) return null;
 
   try {
@@ -38,12 +61,60 @@ export function getInstalledDesktopVersion(): string | null {
   }
 }
 
+// `reg query` is built into every Windows install (no PowerShell
+// execution-policy concerns) — reads the DisplayVersion NSIS wrote at
+// install time.
+function getInstalledDesktopVersionWindows(): string | null {
+  try {
+    const output = execFileSync(
+      'reg',
+      ['query', WINDOWS_UNINSTALL_KEY, '/v', 'DisplayVersion'],
+      { encoding: 'utf-8' },
+    );
+    return output.match(/DisplayVersion\s+REG_SZ\s+(\S+)/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// AppImages don't expose version metadata without executing them, so
+// installOrUpdateDesktop writes a plain-text sidecar file next to the
+// binary at install time and this just reads it back.
+function getInstalledDesktopVersionLinux(): string | null {
+  if (!existsSync(LINUX_APPIMAGE_PATH) || !existsSync(LINUX_VERSION_FILE))
+    return null;
+
+  try {
+    return readFileSync(LINUX_VERSION_FILE, 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+// Reads the currently-installed desktop app's version, or null if it
+// isn't installed (or the platform isn't supported) — both call sites
+// treat that as "nothing to update/detect", not an error.
+export function getInstalledDesktopVersion(): string | null {
+  switch (process.platform) {
+    case 'darwin':
+      return getInstalledDesktopVersionMac();
+    case 'win32':
+      return getInstalledDesktopVersionWindows();
+    case 'linux':
+      return getInstalledDesktopVersionLinux();
+    default:
+      return null;
+  }
+}
+
 // The releases list is shared with the CLI's `deadrop@*` tags — take the
-// first entry whose tag is a desktop release, then resolve the .dmg/.sha256
-// asset names from that release's own asset list rather than constructing
-// them from the tag (the .dmg's filename is derived from tauri.conf.json's
-// version at build time, not necessarily the git tag).
+// first entry whose tag is a desktop release, then resolve this
+// platform's asset from that release's own asset list rather than
+// constructing the filename (it's derived from tauri.conf.json's version
+// at build time, not necessarily the git tag).
 export async function fetchLatestDesktopRelease(): Promise<DesktopRelease | null> {
+  if (!['darwin', 'win32', 'linux'].includes(process.platform)) return null;
+
   const res = await fetch(GITHUB_RELEASES_URL);
 
   if (!res.ok)
@@ -61,44 +132,55 @@ export async function fetchLatestDesktopRelease(): Promise<DesktopRelease | null
   );
   if (!release) return null;
 
-  const dmg = release.assets.find((a) => a.name.endsWith('.dmg'));
-  const dmgSha256 = release.assets.find((a) =>
-    a.name.endsWith('.dmg.sha256'),
+  // Windows publishes both a `-setup.exe` (NSIS) and a `.msi` — only the
+  // NSIS installer supports the silent `/S` flag installOrUpdateDesktop
+  // relies on, so match that specifically rather than any `.exe`/`.msi`.
+  const asset = release.assets.find((a) =>
+    process.platform === 'win32'
+      ? a.name.endsWith('-setup.exe')
+      : process.platform === 'linux'
+        ? a.name.endsWith('.AppImage')
+        : a.name.endsWith('.dmg'),
   );
-  if (!dmg || !dmgSha256) return null;
+  const assetSha256 = release.assets.find(
+    (a) => a.name === `${asset?.name}.sha256`,
+  );
+  if (!asset || !assetSha256) return null;
 
   return {
     version: release.tag_name.replace(/^deadrop-desktop@/, ''),
-    dmgUrl: dmg.browser_download_url,
-    dmgSha256Url: dmgSha256.browser_download_url,
+    assetUrl: asset.browser_download_url,
+    assetSha256Url: assetSha256.browser_download_url,
   };
 }
 
-// Download, verify checksum, mount, copy to /Applications (replacing any
-// existing install), unmount. Throws on any failure — callers decide how
-// to present it (deadrop desktop install treats it as fatal, deadrop
-// update logs it as a non-fatal warning since the CLI's own update already
-// succeeded by that point).
-export async function installOrUpdateDesktop(
+async function downloadAndVerify(
+  release: DesktopRelease,
+  destPath: string,
+): Promise<void> {
+  await downloadWithProgress(release.assetUrl, destPath, (received, total) => {
+    if (!process.stdout.isTTY) return;
+    const pct = total ? Math.round((received / total) * 100) : 0;
+    process.stdout.write(`\rDownloading... ${pct}%`);
+    if (total && received >= total) process.stdout.write('\n');
+  });
+
+  const expectedChecksum = await fetchExpectedChecksum(
+    release.assetSha256Url,
+  );
+  const valid = await verifyChecksum(destPath, expectedChecksum);
+  if (!valid)
+    throw new Error('Checksum verification failed — install aborted.');
+}
+
+async function installOrUpdateDesktopMac(
   release: DesktopRelease,
 ): Promise<void> {
   const scratchDir = mkdtempSync(join(tmpdir(), 'deadrop-desktop-'));
   const dmgPath = join(scratchDir, 'deadrop.dmg');
 
   try {
-    await downloadWithProgress(release.dmgUrl, dmgPath, (received, total) => {
-      if (!process.stdout.isTTY) return;
-      const pct = total ? Math.round((received / total) * 100) : 0;
-      process.stdout.write(`\rDownloading... ${pct}%`);
-      if (total && received >= total) process.stdout.write('\n');
-    });
-
-    const expectedChecksum = await fetchExpectedChecksum(
-      release.dmgSha256Url,
-    );
-    const valid = await verifyChecksum(dmgPath, expectedChecksum);
-    if (!valid)
-      throw new Error('Checksum verification failed — install aborted.');
+    await downloadAndVerify(release, dmgPath);
 
     const mountOutput = execFileSync(
       'hdiutil',
@@ -108,7 +190,8 @@ export async function installOrUpdateDesktop(
     const mountPoint = parseMountPoint(mountOutput);
 
     try {
-      if (existsSync(DESKTOP_APP_PATH)) rmSync(DESKTOP_APP_PATH, { recursive: true });
+      if (existsSync(DESKTOP_APP_PATH))
+        rmSync(DESKTOP_APP_PATH, { recursive: true });
 
       execFileSync('ditto', [
         join(mountPoint, 'deadrop.app'),
@@ -119,6 +202,79 @@ export async function installOrUpdateDesktop(
     }
   } finally {
     rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+// Tauri's NSIS installer supports silent installs via the standard NSIS
+// `/S` flag — installs per-user (no admin prompt) to the default location
+// baked into the installer, and registers the uninstall entry
+// getInstalledDesktopVersion() reads back.
+async function installOrUpdateDesktopWindows(
+  release: DesktopRelease,
+): Promise<void> {
+  const scratchDir = mkdtempSync(join(tmpdir(), 'deadrop-desktop-'));
+  const exePath = join(scratchDir, 'deadrop-setup.exe');
+
+  try {
+    await downloadAndVerify(release, exePath);
+    execFileSync(exePath, ['/S']);
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+// AppImages are self-contained — "installing" is just placing an
+// executable file, no package manager involved. Same ~/.local/bin
+// convention install.sh already uses for the CLI binary itself.
+async function installOrUpdateDesktopLinux(
+  release: DesktopRelease,
+): Promise<void> {
+  const scratchDir = mkdtempSync(join(tmpdir(), 'deadrop-desktop-'));
+  const tmpPath = join(scratchDir, 'deadrop-desktop.AppImage');
+
+  try {
+    await downloadAndVerify(release, tmpPath);
+    chmodSync(tmpPath, 0o755);
+
+    mkdirSync(LINUX_INSTALL_DIR, { recursive: true });
+    // copy+unlink, not rename — scratchDir (tmpdir) and LINUX_INSTALL_DIR
+    // can be on different filesystems, where rename() fails with EXDEV.
+    copyFileSync(tmpPath, LINUX_APPIMAGE_PATH);
+    writeFileSync(LINUX_VERSION_FILE, release.version);
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+// Download, verify checksum, and install/update in place. Throws on any
+// failure — callers decide how to present it (deadrop desktop install
+// treats it as fatal, deadrop update logs it as a non-fatal warning since
+// the CLI's own update already succeeded by that point).
+export async function installOrUpdateDesktop(
+  release: DesktopRelease,
+): Promise<void> {
+  switch (process.platform) {
+    case 'darwin':
+      return installOrUpdateDesktopMac(release);
+    case 'win32':
+      return installOrUpdateDesktopWindows(release);
+    case 'linux':
+      return installOrUpdateDesktopLinux(release);
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+// Human-readable install location for the post-install message — Windows
+// omits one since the NSIS installer, not us, decides where it lands.
+export function getDesktopInstallLocation(): string | null {
+  switch (process.platform) {
+    case 'darwin':
+      return DESKTOP_APP_PATH;
+    case 'linux':
+      return LINUX_APPIMAGE_PATH;
+    default:
+      return null;
   }
 }
 

--- a/cli/tests/unit/update-desktop.spec.ts
+++ b/cli/tests/unit/update-desktop.spec.ts
@@ -4,6 +4,10 @@ import {
   parseMountPoint,
 } from 'lib/update/desktop';
 
+const withPlatform = (platform: string) => {
+  vi.stubGlobal('process', { ...process, platform });
+};
+
 describe('parseMountPoint', () => {
   it('extracts the /Volumes path from hdiutil attach output', () => {
     const output = `/dev/disk4          \tGUID_partition_scheme
@@ -25,38 +29,91 @@ describe('fetchLatestDesktopRelease', () => {
     vi.unstubAllGlobals();
   });
 
-  it('skips CLI releases and resolves the newest desktop tag + assets', async () => {
+  const stubReleases = (assets: Array<{ name: string; browser_download_url: string }>) =>
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
         json: async () => [
           { tag_name: 'deadrop@2.0.0', assets: [] },
-          {
-            tag_name: 'deadrop-desktop@1.2.0',
-            assets: [
-              {
-                name: 'deadrop_1.2.0_universal.dmg',
-                browser_download_url: 'https://example.com/deadrop.dmg',
-              },
-              {
-                name: 'deadrop_1.2.0_universal.dmg.sha256',
-                browser_download_url: 'https://example.com/deadrop.dmg.sha256',
-              },
-            ],
-          },
+          { tag_name: 'deadrop-desktop@1.2.0', assets },
         ],
       }),
     );
 
+  it('resolves the macOS .dmg asset', async () => {
+    withPlatform('darwin');
+    stubReleases([
+      {
+        name: 'deadrop_1.2.0_universal.dmg',
+        browser_download_url: 'https://example.com/deadrop.dmg',
+      },
+      {
+        name: 'deadrop_1.2.0_universal.dmg.sha256',
+        browser_download_url: 'https://example.com/deadrop.dmg.sha256',
+      },
+    ]);
+
     await expect(fetchLatestDesktopRelease()).resolves.toEqual({
       version: '1.2.0',
-      dmgUrl: 'https://example.com/deadrop.dmg',
-      dmgSha256Url: 'https://example.com/deadrop.dmg.sha256',
+      assetUrl: 'https://example.com/deadrop.dmg',
+      assetSha256Url: 'https://example.com/deadrop.dmg.sha256',
     });
   });
 
+  it('resolves the Windows NSIS -setup.exe asset, not the .msi', async () => {
+    withPlatform('win32');
+    stubReleases([
+      {
+        name: 'deadrop_1.2.0_x64-setup.exe',
+        browser_download_url: 'https://example.com/deadrop-setup.exe',
+      },
+      {
+        name: 'deadrop_1.2.0_x64-setup.exe.sha256',
+        browser_download_url: 'https://example.com/deadrop-setup.exe.sha256',
+      },
+      {
+        name: 'deadrop_1.2.0_x64_en-US.msi',
+        browser_download_url: 'https://example.com/deadrop.msi',
+      },
+    ]);
+
+    await expect(fetchLatestDesktopRelease()).resolves.toEqual({
+      version: '1.2.0',
+      assetUrl: 'https://example.com/deadrop-setup.exe',
+      assetSha256Url: 'https://example.com/deadrop-setup.exe.sha256',
+    });
+  });
+
+  it('resolves the Linux .AppImage asset', async () => {
+    withPlatform('linux');
+    stubReleases([
+      {
+        name: 'deadrop_1.2.0_amd64.AppImage',
+        browser_download_url: 'https://example.com/deadrop.AppImage',
+      },
+      {
+        name: 'deadrop_1.2.0_amd64.AppImage.sha256',
+        browser_download_url: 'https://example.com/deadrop.AppImage.sha256',
+      },
+    ]);
+
+    await expect(fetchLatestDesktopRelease()).resolves.toEqual({
+      version: '1.2.0',
+      assetUrl: 'https://example.com/deadrop.AppImage',
+      assetSha256Url: 'https://example.com/deadrop.AppImage.sha256',
+    });
+  });
+
+  it('returns null on an unsupported platform', async () => {
+    withPlatform('freebsd');
+    stubReleases([]);
+
+    await expect(fetchLatestDesktopRelease()).resolves.toBeNull();
+  });
+
   it('returns null when no desktop release exists', async () => {
+    withPlatform('darwin');
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -68,21 +125,15 @@ describe('fetchLatestDesktopRelease', () => {
     await expect(fetchLatestDesktopRelease()).resolves.toBeNull();
   });
 
-  it('returns null when the release has no .dmg asset', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => [
-          { tag_name: 'deadrop-desktop@1.2.0', assets: [] },
-        ],
-      }),
-    );
+  it("returns null when the release has no matching asset for this platform", async () => {
+    withPlatform('darwin');
+    stubReleases([]);
 
     await expect(fetchLatestDesktopRelease()).resolves.toBeNull();
   });
 
   it('throws when the GitHub releases API request fails', async () => {
+    withPlatform('darwin');
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({

--- a/cli/tests/unit/update.spec.ts
+++ b/cli/tests/unit/update.spec.ts
@@ -47,15 +47,19 @@ describe('update', () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it('skips the desktop check on non-macOS', async () => {
+  it('checks for desktop updates on non-macOS platforms too', async () => {
     withPlatform('linux');
-    const { getInstalledDesktopVersion } = await import('lib/update');
+    const { getInstalledDesktopVersion, fetchLatestDesktopRelease } =
+      await import('lib/update');
     const update = (await import('actions/update')).default;
     vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
+    vi.mocked(getInstalledDesktopVersion).mockReturnValue(null);
+
     await update();
 
-    expect(getInstalledDesktopVersion).not.toHaveBeenCalled();
+    expect(getInstalledDesktopVersion).toHaveBeenCalled();
+    expect(fetchLatestDesktopRelease).not.toHaveBeenCalled();
   });
 
   it('does not prompt when desktop is not installed', async () => {
@@ -89,8 +93,8 @@ describe('update', () => {
     vi.mocked(getInstalledDesktopVersion).mockReturnValue('0.1.0');
     vi.mocked(fetchLatestDesktopRelease).mockResolvedValue({
       version: '0.2.0',
-      dmgUrl: 'https://example.com/deadrop.dmg',
-      dmgSha256Url: 'https://example.com/deadrop.dmg.sha256',
+      assetUrl: 'https://example.com/deadrop.dmg',
+      assetSha256Url: 'https://example.com/deadrop.dmg.sha256',
     });
     vi.mocked(isNewerVersion).mockReturnValue(true);
     vi.mocked(confirm).mockResolvedValue(true);
@@ -118,8 +122,8 @@ describe('update', () => {
     vi.mocked(getInstalledDesktopVersion).mockReturnValue('0.1.0');
     vi.mocked(fetchLatestDesktopRelease).mockResolvedValue({
       version: '0.2.0',
-      dmgUrl: 'https://example.com/deadrop.dmg',
-      dmgSha256Url: 'https://example.com/deadrop.dmg.sha256',
+      assetUrl: 'https://example.com/deadrop.dmg',
+      assetSha256Url: 'https://example.com/deadrop.dmg.sha256',
     });
     vi.mocked(isNewerVersion).mockReturnValue(true);
     vi.mocked(confirm).mockResolvedValue(false);

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -56,7 +56,19 @@ Local vault at `/vault`: Rust-side SQLite via the `libsql` crate
 (`src-tauri/src/vault_store.rs`), optional Turso cloud sync
 (`src/lib/vault-cloud.ts`), gated by `isExperimental` (`src/lib/billing.ts`).
 Encryption reuses `shared/lib/secrets.ts` directly; config persisted to
-`.deadroprc` (same pattern as CLI/vscode-extension).
+`.deadroprc` (same shape as CLI/vscode-extension, but read/written via Rust
+commands — `read_app_vault_config`/`write_app_vault_config` in
+`src-tauri/src/config_import.rs` — not `@tauri-apps/plugin-fs`, whose
+`$APPDATA/**` capability scope doesn't reliably match a file directly at
+$APPDATA's root and silently no-op'd writes).
+
+First visit to `/vault` with no config prompts "Create your vault" rather
+than silently auto-bootstrapping one (`src/routes/Vault.tsx`). The CLI and
+desktop app share one default vault automatically — the CLI falls back to
+this same app-data-scoped config when it finds no project-scoped
+`.deadroprc` (`cli/lib/global-config.ts`). Project-scoped vaults created by
+the CLI/vscode-extension can also be explicitly linked in via "Import
+vault" (`src/lib/vault-config.ts`'s `pickExternalVaultConfig`).
 
 ## Auth keychain backend
 

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -87,7 +87,11 @@ time; it still needs a running D-Bus session + Secret Service provider
 - `inject` / `secret` command parity with the CLI (`vault` CRUD is done via
   the in-app UI).
 - CLI-driven install/update (`deadrop desktop install`, `cli/lib/update/desktop.ts`)
-  is still macOS-only (`hdiutil`/`ditto`/`plutil`, hardcoded `/Applications`).
-  `desktop_publish_workflow.yml` now builds and publishes Linux (AppImage) and
-  Windows (NSIS) bundles alongside macOS, but nothing installs them yet.
+  now covers macOS (`hdiutil`/`ditto`/`plutil`, `/Applications`), Windows (silent
+  NSIS install via `/S`, version read from the uninstall registry key — untested
+  against a real Windows box, best-effort), and Linux (AppImage in `~/.local/bin`,
+  version tracked via a sidecar file since AppImages don't expose it directly).
+  `install-desktop.sh` mirrors macOS/Linux; no native Windows shell support yet
+  (`install-desktop.ps1` is a tracked fast-follow — Windows installs go through
+  the CLI for now).
 - Signing — every platform ships unsigned (Gatekeeper/SmartScreen warnings).

--- a/specs/desktop-cli-install.md
+++ b/specs/desktop-cli-install.md
@@ -1,5 +1,15 @@
 # Desktop Install via CLI Spec
 
+**Update (landed):** the "macOS only" scoping throughout this doc (Goal,
+Scope, error-message wording) is superseded — `deadrop desktop install`
+and `installOrUpdateDesktop()` now support Windows (silent NSIS install)
+and Linux (AppImage in `~/.local/bin`) too, once desktop started
+publishing builds for those platforms. `install-desktop.sh` gained Linux
+support in the same pass; it still doesn't cover Windows (bash doesn't run
+natively there) — an `install-desktop.ps1` is a tracked fast-follow, so
+Windows users go through the CLI. See `cli/lib/update/desktop.ts`,
+`cli/actions/desktop/install.ts`, `cli/install-desktop.sh`.
+
 ## Goal
 
 Let users install *and update* the desktop app two ways — a new

--- a/specs/desktop-vault.md
+++ b/specs/desktop-vault.md
@@ -160,6 +160,12 @@ vscode's `CloudSyncButton`'s `canCloudSync`/`onLocked` pattern
 
 ## Multi-Vault & Default Vault
 
+**Update (PR #145, landed):** the auto-bootstrap-on-load design below was
+changed before shipping — first visit to `/vault` with no config now shows
+an explicit "Create your vault" prompt instead of silently bootstrapping a
+`default` vault. Same `initConfig()`/`vault()` builders, just gated behind
+a user action (`desktop/src/routes/Vault.tsx`, `use-vault.tsx`).
+
 Mirrors `cli/actions/init.ts` + `shared/lib/vault.ts`'s `initConfig()`
 exactly: first time the desktop Vault page loads with no config present,
 auto-bootstrap one vault named `default` (via `initConfig()`, unchanged)
@@ -203,16 +209,25 @@ dropping the `Badge`/"Coming soon".
   patterns already used elsewhere in this codebase.
 - **Cloud sync provisioning failure** (network error, `restricted()` 403 if
   claims are stale): notification + cloud toggle reverts to off.
-- **Corrupt/missing config file**: treated as "no config" → re-run the
-  `default` vault bootstrap (self-healing, same spirit as the auth work's
-  keychain migration).
+- **Corrupt/missing config file**: treated as "no config" → shows the
+  "Create your vault" prompt (see update note above; no longer an
+  automatic re-bootstrap).
 
 ## Out of Scope
 
-- Migrating an existing CLI-created local vault into desktop (or vice
+**Update (PR #145, landed):** both items below shipped — the CLI now
+falls back to the same app-data-scoped config desktop uses when no
+project-scoped `.deadroprc` exists (`cli/lib/global-config.ts`), and
+desktop can import a project-scoped CLI/vscode vault via "Import vault"
+(`pickExternalVaultConfig` in `desktop/src/lib/vault-config.ts`). The
+imported vault's DB file stays wherever the project put it — only the
+config entry is copied.
+
+- ~~Migrating an existing CLI-created local vault into desktop (or vice
   versa) — no shared vault-file location between CLI and desktop in this
-  iteration; each platform has its own `<app data dir>/vaults/`.
-- `vault export`/`import` (CLI-only for now).
+  iteration; each platform has its own `<app data dir>/vaults/`.~~
+- ~~`vault export`/`import` (CLI-only for now).~~ (import landed for
+  desktop; export remains CLI-only)
 - Upgrading environment-key storage to the OS keychain (flagged above,
   deliberately deferred).
 - Web's OPFS-based approach — not applicable to Tauri, not revisited here.
@@ -221,8 +236,9 @@ dropping the `Badge`/"Coming soon".
 
 1. `cargo check`/`cargo build` on `desktop/src-tauri` after adding `libsql`
    and `vault_store.rs`.
-2. Fresh app launch (no config) → visiting `/vault` auto-bootstraps a
-   `default` vault, `development`/`production` environments visible.
+2. Fresh app launch (no config) → visiting `/vault` shows the "Create your
+   vault" prompt; creating one shows `development`/`production`
+   environments (see update note above — no longer auto-bootstraps).
 3. Add/edit/rename/delete a secret in `development` → persists across app
    restart (re-open `/vault`, secret still there, still decrypts correctly).
 4. Create a second named vault, switch between the two — each has its own

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -133,6 +133,11 @@ const baseConfig = {
         destination:
           'https://raw.githubusercontent.com/dallen4/deadrop/main/cli/install.sh',
       },
+      {
+        source: '/install-desktop.sh',
+        destination:
+          'https://raw.githubusercontent.com/dallen4/deadrop/main/cli/install-desktop.sh',
+      },
     ];
   },
   headers() {

--- a/web/pages/docs/faqs.mdx
+++ b/web/pages/docs/faqs.mdx
@@ -92,7 +92,7 @@ No. deadrop has four surfaces:
 - **Web app**: `deadrop.io`, also installable as a PWA
 - **CLI**: `deadrop` on npm or via the install script. Runs on macOS, Linux, and Windows
 - **VS Code extension**: drop, grab, and manage local or cloud-synced vaults directly from your editor (experimental, Supporter+ plans)
-- **Desktop app**: a native app with drop, grab, and a local/cloud-synced vault in one window (experimental, macOS only), install via `deadrop desktop install`
+- **Desktop app**: a native app with drop, grab, and a local/cloud-synced vault in one window (experimental, macOS/Windows/Linux). Install on macOS via `deadrop desktop install`; on Windows/Linux, download the build from [GitHub Releases](https://github.com/dallen4/deadrop/releases)
 
 All four implement the same cryptographic protocol and can interoperate. For example, you can drop from the CLI and grab in the browser.
 

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -78,7 +78,7 @@ Run the setup wizard once after install:
 deadrop init
 ```
 
-This creates a config file (default location is `.deadrop/` in your home directory) and your first local vault. The config tracks which vault is active and stores per-vault metadata:
+This creates a `.deadroprc` config file in the current directory and your first local vault in a `.deadrop/` folder alongside it — config is scoped per project, so different projects can have different vaults. If a command runs somewhere with no project-scoped config, the CLI falls back to one shared default vault stored in your OS app-data directory — the same one the [desktop app](/docs/features/desktop) uses, so a vault created in either is immediately usable in the other with no import step. The config tracks which vault is active and stores per-vault metadata:
 
 <CopyableCode
   value={`active_vault:

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -255,7 +255,7 @@ deadrop inject -v prod -- pnpm build
 
 ### `desktop install`
 
-Install (or update, if already installed) the [desktop app](/docs/features/desktop). macOS only for now.
+Install (or update, if already installed) the [desktop app](/docs/features/desktop). Works on macOS, Windows, and Linux — silent install on all three (macOS via `.dmg`, Windows via a silent NSIS install, Linux via an AppImage placed in `~/.local/bin`).
 
 ```
 deadrop desktop install

--- a/web/pages/docs/features/desktop.mdx
+++ b/web/pages/docs/features/desktop.mdx
@@ -2,10 +2,11 @@ import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 
 # 🖥️ Desktop App
 
-> **Experimental, macOS/Windows/Linux.** `deadrop desktop install`/`install-desktop.sh` only
-> know how to install on macOS for now — on Windows/Linux, grab the build directly from
-> [GitHub Releases](https://github.com/dallen4/deadrop/releases). The app is unsigned on every
-> platform, so expect an "unidentified developer"/SmartScreen warning on first launch.
+> **Experimental, macOS/Windows/Linux.** `deadrop desktop install` installs silently on all
+> three; `install-desktop.sh` covers macOS/Linux only (no native Windows shell support yet —
+> use the CLI there, or grab the build directly from
+> [GitHub Releases](https://github.com/dallen4/deadrop/releases)). The app is unsigned on
+> every platform, so expect an "unidentified developer"/SmartScreen warning on first launch.
 
 <DocsSectionTitle
   id={'what-it-does'}

--- a/web/pages/docs/features/desktop.mdx
+++ b/web/pages/docs/features/desktop.mdx
@@ -2,8 +2,10 @@ import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 
 # 🖥️ Desktop App
 
-> **Experimental, macOS only.** Windows and Linux builds are on the way; the app is unsigned
-> for now, so macOS will show an "unidentified developer" warning on first launch.
+> **Experimental, macOS/Windows/Linux.** `deadrop desktop install`/`install-desktop.sh` only
+> know how to install on macOS for now — on Windows/Linux, grab the build directly from
+> [GitHub Releases](https://github.com/dallen4/deadrop/releases). The app is unsigned on every
+> platform, so expect an "unidentified developer"/SmartScreen warning on first launch.
 
 <DocsSectionTitle
   id={'what-it-does'}
@@ -48,9 +50,12 @@ transfer runs the same peer-to-peer path as the browser, not the CLI's Node.js W
   label={'Vault access'}
 />
 
-The Vault tab gives you a native local vault out of the box, stored on-device. Signed-in
-users with cloud access can enable Turso-backed cloud sync for a vault from the same view,
-so its secrets stay available across devices.
+The Vault tab prompts you to create a vault the first time you visit it, rather than
+creating one silently. It's stored on-device, and shares a default vault with the CLI
+automatically — no setup needed. Signed-in users with cloud access can enable Turso-backed
+cloud sync for a vault from the same view, so its secrets stay available across devices. You
+can also link an existing project-scoped vault created by the CLI or the VS Code extension
+into the desktop app via "Import vault" in the vault switcher.
 
 <DocsSectionTitle
   id={'related'}

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -56,7 +56,7 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 ### Desktop app
 
-- **Native desktop app**: a Tauri-based hub for drop, grab, and a native local/cloud-synced vault, sharing your CLI sign-in via the OS keychain. Builds publish for macOS, Windows, and Linux; `deadrop desktop install`/`install-desktop.sh` (macOS only for now) is the only CLI-driven install path — Windows/Linux users grab the build directly from [GitHub Releases](https://github.com/dallen4/deadrop/releases). Unsigned build; code-signing is still to come. See the [Desktop docs](/docs/features/desktop) for details.
+- **Native desktop app**: a Tauri-based hub for drop, grab, and a native local/cloud-synced vault, sharing your CLI sign-in via the OS keychain. Builds publish for macOS, Windows, and Linux. `deadrop desktop install` works (silently) on all three; `install-desktop.sh` covers macOS/Linux only (no native Windows shell) — Windows users use the CLI or grab the build directly from [GitHub Releases](https://github.com/dallen4/deadrop/releases). A native PowerShell installer is a tracked fast-follow. Unsigned build; code-signing is still to come. See the [Desktop docs](/docs/features/desktop) for details.
 - **Shared default vault**: the desktop app and CLI automatically share one default vault (same OS app-data location), so a vault created in either is immediately usable in the other with no setup. Project-scoped CLI vaults can also be linked into the desktop app via its "Import vault" option.
 
 ### Vaults

--- a/web/pages/docs/features/index.mdx
+++ b/web/pages/docs/features/index.mdx
@@ -56,7 +56,8 @@ For per-surface usage, see the [CLI](/docs/features/cli) and [VS Code](/docs/fea
 
 ### Desktop app
 
-- **Native desktop app** (macOS only): a Tauri-based hub for drop, grab, and a native local/cloud-synced vault, sharing your CLI sign-in via the OS keychain. Install via `deadrop desktop install` or `install-desktop.sh`. Unsigned build; Windows/Linux and code-signing are still to come. See the [Desktop docs](/docs/features/desktop) for details.
+- **Native desktop app**: a Tauri-based hub for drop, grab, and a native local/cloud-synced vault, sharing your CLI sign-in via the OS keychain. Builds publish for macOS, Windows, and Linux; `deadrop desktop install`/`install-desktop.sh` (macOS only for now) is the only CLI-driven install path — Windows/Linux users grab the build directly from [GitHub Releases](https://github.com/dallen4/deadrop/releases). Unsigned build; code-signing is still to come. See the [Desktop docs](/docs/features/desktop) for details.
+- **Shared default vault**: the desktop app and CLI automatically share one default vault (same OS app-data location), so a vault created in either is immediately usable in the other with no setup. Project-scoped CLI vaults can also be linked into the desktop app via its "Import vault" option.
 
 ### Vaults
 

--- a/web/pages/docs/overview.mdx
+++ b/web/pages/docs/overview.mdx
@@ -42,7 +42,7 @@ All keys are exchanged through peer-to-peer connections over WebRTC allowing all
 - 🧪 local vaults (CLI stable, web experimental)
 - 🧪 cloud-synced vaults (Supporter+ plans)
 - 🧪 VS Code Extension (Supporter+ plans, experimental)
-- 🧪 Desktop app (macOS, experimental)
+- 🧪 Desktop app (macOS/Windows/Linux, experimental)
 - 🧪 multidrop: multiple recipients per drop (Supporter+)
 - ⬜️ drop passcode protection
 - ⬜️ dynamic QR codes
@@ -71,4 +71,4 @@ The deadrop VS Code extension is available on the Marketplace for Supporter+ pla
 
 ## Desktop App
 
-An experimental native desktop app (macOS only for now) is available via `deadrop desktop install` from the CLI, or `install-desktop.sh`. It's built to be the "hub" for engaged users, with drop, grab, and a native vault in one window. See the [Desktop docs](/docs/features/desktop) for details.
+An experimental native desktop app, with builds for macOS, Windows, and Linux, is available via `deadrop desktop install` from the CLI (macOS only for now) or `install-desktop.sh`, or by downloading the build directly from [GitHub Releases](https://github.com/dallen4/deadrop/releases) on Windows/Linux. It's built to be the "hub" for engaged users, with drop, grab, and a native vault in one window. See the [Desktop docs](/docs/features/desktop) for details.

--- a/web/pages/docs/overview.mdx
+++ b/web/pages/docs/overview.mdx
@@ -71,4 +71,4 @@ The deadrop VS Code extension is available on the Marketplace for Supporter+ pla
 
 ## Desktop App
 
-An experimental native desktop app, with builds for macOS, Windows, and Linux, is available via `deadrop desktop install` from the CLI (macOS only for now) or `install-desktop.sh`, or by downloading the build directly from [GitHub Releases](https://github.com/dallen4/deadrop/releases) on Windows/Linux. It's built to be the "hub" for engaged users, with drop, grab, and a native vault in one window. See the [Desktop docs](/docs/features/desktop) for details.
+An experimental native desktop app, with builds for macOS, Windows, and Linux, is available via `deadrop desktop install` from the CLI on any platform, `install-desktop.sh` on macOS/Linux, or by downloading the build directly from [GitHub Releases](https://github.com/dallen4/deadrop/releases). It's built to be the "hub" for engaged users, with drop, grab, and a native vault in one window. See the [Desktop docs](/docs/features/desktop) for details.


### PR DESCRIPTION
## Summary

Two batches of work, both against `main`:

**1. Doc hydration** (`/hydrate-docs`) — reconciled docs against everything merged since the last doc-touching commit (PRs #142-#147):
- Documented the desktop vault init prompt, "Import vault" feature, and the new CLI↔desktop shared global vault config.
- Cross-file consistency sweep found the desktop app described as "macOS only" in 4 places, contradicting the actual build matrix (macOS/Windows/Linux all publish) — and `cli.mdx` describing the config file location incorrectly (predates this PR).
- `specs/desktop-vault.md`: marked the auto-bootstrap-on-load design and "no shared vault-file location" note as superseded, historical text struck through rather than deleted.

**2. Desktop install for Windows/Linux** — found and fixed while updating the "macOS only" docs above:
- **Bug**: `curl -fsSL https://deadrop.io/install-desktop.sh | sh` 404'd — `web/next.config.mjs` had a rewrite for `/install.sh` but never one for `/install-desktop.sh`.
- **Feature**: now that desktop publishes Windows/Linux builds, `deadrop desktop install`/`deadrop update` and `install-desktop.sh` support them:
  - **Windows**: silent NSIS install via `/S`, version detection via the uninstall registry key (best-effort — untested against a real Windows machine, degrades to "not installed" rather than crashing if the guessed key is wrong)
  - **Linux**: AppImage placed in `~/.local/bin` (matching `install.sh`'s existing CLI-binary convention), version tracked via a plain-text sidecar file since AppImages don't expose version metadata without executing them
  - `install-desktop.sh` gained the Linux path; Windows isn't supported there (bash doesn't run natively) — points users to the CLI instead. `install-desktop.ps1` is a tracked fast-follow (noted in `desktop/CLAUDE.md`, `specs/desktop-cli-install.md`)
- Docs updated across all three tiers again to reflect the real platform support.

Changesets: `desktop` patch (bundled from earlier work already in this PR), `cli` minor (new cross-platform install capability).

## Test plan
- [x] `install-desktop.sh` syntax-checked (`bash -n`)
- [x] CLI unit tests: 104 passing, including new coverage for per-platform asset matching (macOS `.dmg`, Windows `-setup.exe` not `.msi`, Linux `.AppImage`)
- [x] `tsc --noEmit`: no new errors beyond pre-existing repo-wide ones
- [x] Full pre-push suite: 223 tests passing
- [ ] Real install verified only on macOS (existing path, unchanged). Windows/Linux install paths are new and not yet exercised against a real machine — first real-world run will be the actual test