### PR TITLE
linux install sandbox + POSIX install scripts, desktop uninstall, version sync

### DIFF
--- a/.changeset/desktop-uninstall.md
+++ b/.changeset/desktop-uninstall.md
@@ -1,0 +1,9 @@
+---
+'cli': minor
+---
+
+Added `deadrop desktop uninstall`, and an `--uninstall` flag to `install-desktop.sh`. Installing the desktop app on Linux writes to three places (the AppImage in `~/.local/bin`, a `.desktop` entry, and an icon under the hicolor theme), and nothing removed any of them — anyone who tried the app and deleted the AppImage by hand was left with a dead launcher in their application menu pointing at a missing binary.
+
+Both paths remove the AppImage, its version sidecar, the desktop entry, and the installed icon, then refresh the desktop and icon caches. Icons are swept across every hicolor size bucket, since the install picks its bucket from the extracted PNG's own dimensions and uninstall can't recompute it. On macOS this removes `/Applications/deadrop.app`; on Windows it points at Settings > Apps, since the NSIS installer owns its own uninstaller.
+
+The flag exists on the shell script as well as the CLI because installing via `curl … | sh` doesn't get you the CLI, which would have left those users with no way to undo the install.

--- a/.changeset/desktop-version-sync.md
+++ b/.changeset/desktop-version-sync.md
@@ -1,0 +1,7 @@
+---
+'desktop': patch
+---
+
+The desktop version is now synced from `package.json` into `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock` as part of `changeset version`. Changesets only bumps `package.json`, but Tauri names every bundle from `tauri.conf.json`, so the two drifted silently: the `deadrop-desktop@0.2.2` release shipped a full set of assets named `0.1.0`, which broke checksum lookups and made the installed version impossible to identify.
+
+`pnpm -F desktop sync-version` writes the three files, and `--check` fails instead of writing so Desktop CI catches a bump that bypassed changesets.

--- a/.changeset/linux-desktop-entry.md
+++ b/.changeset/linux-desktop-entry.md
@@ -1,0 +1,5 @@
+---
+'cli': patch
+---
+
+Installing the desktop app on Linux now registers it with the desktop environment. `deadrop desktop install` and `install-desktop.sh` previously placed an AppImage in `~/.local/bin` and stopped, so it never appeared in the application menu. Both now write a freedesktop `.desktop` entry and install the app icon, degrading gracefully when the icon can't be extracted or the desktop-database tools aren't present.

--- a/.changeset/linux-setup-fixes.md
+++ b/.changeset/linux-setup-fixes.md
@@ -1,0 +1,9 @@
+---
+'cli': patch
+---
+
+Three Linux setup fixes found while building the Linux sandbox:
+
+- The keychain-unavailable message no longer hardcodes `apt-get` — it now lists the Ubuntu/Debian, Fedora/RHEL, and Arch commands, matching what `install.sh` already prints. Fedora and Arch users were being told to run a command that doesn't exist on their system.
+- Desktop AppImage selection is now architecture-aware in both `deadrop desktop install` and `install-desktop.sh`. Previously either would take the first `.AppImage` on a release regardless of arch, which would have handed x64 users an aarch64 binary as soon as a second Linux build shipped. A release with no build for your platform now says so explicitly instead of reporting "no release found".
+- `deadrop init` accepts `-y`/`--yes` and skips its `.gitignore` prompt automatically in a non-TTY shell or when `CI` is set, so it can complete unattended in Dockerfiles, CI, and provisioning scripts.

--- a/.changeset/posix-install-scripts.md
+++ b/.changeset/posix-install-scripts.md
@@ -1,0 +1,9 @@
+---
+'cli': patch
+---
+
+`install.sh` and `install-desktop.sh` are now POSIX sh instead of bash. Both are documented as `curl -fsSL https://deadrop.io/install.sh | sh`, but both opened with `set -euo pipefail` — and `/bin/sh` is dash on Debian and Ubuntu, which has no `pipefail`. The documented command therefore failed on line 2 with `set: Illegal option -o pipefail` on the two most common desktop Linux distributions, installing nothing. Fedora and macOS were unaffected because `/bin/sh` is bash there, which is why this went unnoticed.
+
+`install.sh` also used two further bashisms (`&>` redirection and `[[ =~ ]]`), now replaced with POSIX equivalents. Dropping `pipefail` additionally makes the "Could not determine latest release tag" error reachable — previously a release-tag lookup that matched nothing aborted the script silently, before its own error message could print.
+
+The Linux sandbox now runs `install.sh` under `sh` rather than `bash`, so this class of bug fails the suite instead of shipping.

--- a/.github/workflows/desktop_ci_workflow.yml
+++ b/.github/workflows/desktop_ci_workflow.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Tauri names bundles from tauri.conf.json, not package.json, so drift
+      # here ships assets labelled with the wrong version.
+      - name: Check desktop version sync
+        run: pnpm -F desktop sync-version --check
+
       # Prod secrets only (never dev `vars.*`) — mixing dev Clerk creds with the prod Worker breaks auth.
       - name: Build desktop frontend
         env:

--- a/.github/workflows/desktop_publish_workflow.yml
+++ b/.github/workflows/desktop_publish_workflow.yml
@@ -24,20 +24,20 @@ jobs:
             runner: macos-latest
             rust-targets: aarch64-apple-darwin,x86_64-apple-darwin
             args: --target universal-apple-darwin
-            bundle-glob: desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+            bundle-root: desktop/src-tauri/target/universal-apple-darwin/release/bundle
           # ubuntu-22.04, not -latest: Tauri's AppImage bundling links
           # against the runner's glibc, and 22.04's older glibc keeps the
           # result compatible with more end-user distros than 24.04's would.
-          - name: Linux (x86_64 AppImage)
+          - name: Linux (x86_64)
             runner: ubuntu-22.04
             rust-targets: ''
             args: ''
-            bundle-glob: desktop/src-tauri/target/release/bundle/appimage/*.AppImage
-          - name: Windows (x86_64 NSIS)
+            bundle-root: desktop/src-tauri/target/release/bundle
+          - name: Windows (x86_64)
             runner: windows-latest
             rust-targets: ''
             args: ''
-            bundle-glob: desktop/src-tauri/target/release/bundle/nsis/*.exe
+            bundle-root: desktop/src-tauri/target/release/bundle
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -103,18 +103,47 @@ jobs:
 
       # tauri-action doesn't generate checksums (unlike cli_publish_workflow.yml,
       # which explicitly does for every CLI binary) — do it ourselves and
-      # upload alongside the bundle it already published, so every install
+      # upload alongside the bundles it already published, so every install
       # path can verify.
-      - name: Checksum + upload bundle
+      #
+      # tauri.conf.json sets `"targets": "all"`, and tauri-action uploads
+      # every bundle it produces — on Linux that's .deb and .rpm as well as
+      # the AppImage. Checksum the whole bundle directory rather than one
+      # glob per platform: an artifact users can download is an artifact
+      # they must be able to verify, whether or not our own installers
+      # consume it yet.
+      - name: Checksum + upload bundles
         shell: bash
         run: |
-          f=$(ls ${{ matrix.bundle-glob }})
-          if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum "$f" > "$f.sha256"
-          else
-            shasum -a 256 "$f" > "$f.sha256"
+          # find, not a `**` glob — macOS runners ship bash 3.2, which has no
+          # globstar, so `**` would silently match nothing and this step
+          # would pass having checksummed zero files.
+          found=0
+          while IFS= read -r -d '' f; do
+            found=$((found + 1))
+            # Record the basename, not the CI build path, so a user who
+            # downloads the artifact next to its .sha256 can verify with a
+            # plain `sha256sum -c <file>.sha256`.
+            d=$(dirname "$f")
+            b=$(basename "$f")
+            if command -v sha256sum >/dev/null 2>&1; then
+              ( cd "$d" && sha256sum "$b" > "$b.sha256" )
+            else
+              ( cd "$d" && shasum -a 256 "$b" > "$b.sha256" )
+            fi
+            echo "checksummed $b"
+            gh release upload "${{ steps.tag.outputs.tag }}" "$f.sha256" --clobber
+          done < <(find "${{ matrix.bundle-root }}" -type f \( \
+            -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o \
+            -name '*.dmg' -o -name '*.exe' -o -name '*.msi' -o \
+            -name '*.tar.gz' \) -print0)
+          # A silent zero here would republish unverified artifacts, which is
+          # the exact failure this step exists to prevent.
+          if [ "$found" -eq 0 ]; then
+            echo "No bundles found under ${{ matrix.bundle-root }}" >&2
+            exit 1
           fi
-          gh release upload "${{ steps.tag.outputs.tag }}" "$f.sha256"
+          echo "checksummed $found bundle(s)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ cli/lib/bun-inject.ts
 # tauri (desktop) build artifacts
 desktop/src-tauri/target/
 desktop/src-tauri/gen/
+
+# linux sandbox run artifacts
+tests/sandbox/.logs/
+tests/sandbox/.work/

--- a/cli/actions/desktop/install.ts
+++ b/cli/actions/desktop/install.ts
@@ -20,8 +20,11 @@ export async function desktopInstall(
   const release = await fetchLatestDesktopRelease();
 
   if (!release) {
+    // Also covers "a desktop release exists, but publishes no build for
+    // this platform/arch" — naming both beats a bare "not found" when the
+    // real answer is that we don't ship for it yet.
     logError(
-      `No published deadrop desktop release found.\nSee https://github.com/dallen4/deadrop/releases`,
+      `No published deadrop desktop build found for ${process.platform}/${process.arch}.\nSee https://github.com/dallen4/deadrop/releases`,
     );
     return process.exit(1);
   }

--- a/cli/actions/desktop/uninstall.ts
+++ b/cli/actions/desktop/uninstall.ts
@@ -1,0 +1,44 @@
+import {
+  getInstalledDesktopVersion,
+  uninstallDesktop,
+} from 'lib/update/desktop';
+import { logError, logInfo } from 'lib/log';
+
+const SUPPORTED_PLATFORMS = ['darwin', 'win32', 'linux'];
+
+export async function desktopUninstall() {
+  if (!SUPPORTED_PLATFORMS.includes(process.platform)) {
+    logError(`deadrop desktop is not supported on ${process.platform}.`);
+    return process.exit(1);
+  }
+
+  const installedVersion = getInstalledDesktopVersion();
+
+  let result;
+  try {
+    result = uninstallDesktop();
+  } catch (err) {
+    logError(`Uninstall failed: ${(err as Error).message}`);
+    return process.exit(1);
+  }
+
+  if (result.note) {
+    logInfo(result.note);
+    return process.exit(0);
+  }
+
+  // Nothing removed and nothing detected: say so rather than implying we
+  // cleaned something up.
+  if (!result.removed.length) {
+    logInfo('deadrop desktop is not installed.');
+    return process.exit(0);
+  }
+
+  logInfo(
+    `deadrop desktop${installedVersion ? ` v${installedVersion}` : ''} uninstalled:\n${result.removed
+      .map((path) => `  ${path}`)
+      .join('\n')}`,
+  );
+
+  return process.exit(0);
+}

--- a/cli/actions/init.ts
+++ b/cli/actions/init.ts
@@ -12,7 +12,7 @@ import {
   STORAGE_DIR_NAME,
 } from '@shared/lib/constants';
 
-export default async function () {
+export default async function (options: { yes?: boolean } = {}) {
   const defaultConfigPath = resolve(cwd(), CONFIG_FILE_NAME);
   const defaultVaultPath = resolve(
     STORAGE_DIR_NAME,
@@ -39,9 +39,16 @@ We recommend adding the following to your .gitignore:
 ${CONFIG_FILE_NAME}
 ${STORAGE_DIR_NAME}/`);
 
-  const updateGitignore = await confirm({
-    message: 'Would you like to add these?',
-  });
+  // `init` has to complete unattended — Dockerfiles, CI, provisioning
+  // scripts and devcontainers all run it with no TTY, where Inquirer has
+  // nothing to read from and the prompt would hang or throw. Same guard
+  // install.sh:74 already applies to its own prompt.
+  const canPrompt =
+    !options.yes && Boolean(process.stdout.isTTY) && !process.env.CI;
+
+  const updateGitignore = canPrompt
+    ? await confirm({ message: 'Would you like to add these?' })
+    : Boolean(options.yes);
 
   if (updateGitignore) {
     await appendFile(

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -34,7 +34,14 @@ deadrop
     return '';
   });
 
-deadrop.command('init').action(init);
+deadrop
+  .command('init')
+  .description('set up a default vault and config in the current directory')
+  .option(
+    '-y, --yes',
+    'skip prompts and accept defaults (also implied by a non-TTY shell or CI)',
+  )
+  .action(init);
 
 deadrop.command('login').action(login);
 

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -21,6 +21,7 @@ import logout from 'actions/logout';
 import whoami from 'actions/whoami';
 import update from 'actions/update';
 import { desktopInstall } from 'actions/desktop/install';
+import { desktopUninstall } from 'actions/desktop/uninstall';
 import { displayWelcomeMessage } from 'lib/log';
 
 const deadrop = new Command();
@@ -114,6 +115,13 @@ desktopRoot
   )
   .option('--force', 'reinstall even if already on the latest version')
   .action(desktopInstall);
+
+desktopRoot
+  .command('uninstall')
+  .description(
+    'remove the deadrop desktop app and its desktop-environment entry',
+  )
+  .action(desktopUninstall);
 
 // vault commands
 

--- a/cli/install-desktop.sh
+++ b/cli/install-desktop.sh
@@ -1,5 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+# POSIX sh, not bash: the documented install is `curl ... | sh`, and /bin/sh is
+# dash on Debian/Ubuntu. Keep this file free of bashisms.
+set -eu
 
 REPO="dallen4/deadrop"
 APP_NAME="deadrop.app"
@@ -11,7 +13,7 @@ OS="$(uname -s)"
 case "$OS" in
   Darwin|Linux) ;;
   *)
-    # Bash doesn't run natively on Windows (no PowerShell/cmd support) —
+    # No POSIX shell runs natively on Windows (no PowerShell/cmd support) —
     # `deadrop desktop install` (Node, cross-platform) is the real Windows
     # install path for now. A native install-desktop.ps1 is a tracked
     # fast-follow, not built yet.

--- a/cli/install-desktop.sh
+++ b/cli/install-desktop.sh
@@ -30,7 +30,7 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases") || {
+RELEASE_JSON=$(curl -fsSL "${DEADROP_RELEASES_API:-https://api.github.com/repos/${REPO}/releases}") || {
   echo "No published deadrop desktop release found (or network error)." >&2
   echo "See https://github.com/${REPO}/releases" >&2
   exit 1

--- a/cli/install-desktop.sh
+++ b/cli/install-desktop.sh
@@ -124,7 +124,45 @@ else
   mkdir -p "$INSTALL_DIR"
   mv "$ASSET_PATH" "$APPIMAGE_PATH"
 
+  # Without a .desktop entry the AppImage never appears in the app menu.
+  # Mirrors installDesktopEntry() in cli/lib/update/desktop-entry.ts.
+  DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+  # Largest first — .DirIcon is only a 32x32 symlink.
+  ICON_VALUE="$APPIMAGE_PATH"
+  ICON_TMP=$(mktemp -d)
+  for CANDIDATE in \
+    "usr/share/icons/hicolor/256x256@2/apps/deadrop.png" \
+    "usr/share/icons/hicolor/128x128/apps/deadrop.png" \
+    ".DirIcon"; do
+    (cd "$ICON_TMP" && "$APPIMAGE_PATH" --appimage-extract "$CANDIDATE" >/dev/null 2>&1) || continue
+    [ -f "$ICON_TMP/squashfs-root/$CANDIDATE" ] || continue
+    mkdir -p "${DATA_HOME}/icons/hicolor/256x256/apps"
+    cp "$ICON_TMP/squashfs-root/$CANDIDATE" "${DATA_HOME}/icons/hicolor/256x256/apps/deadrop.png"
+    ICON_VALUE="deadrop"
+    break
+  done
+  rm -rf "$ICON_TMP"
+
+  mkdir -p "${DATA_HOME}/applications"
+  cat > "${DATA_HOME}/applications/deadrop.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=deadrop
+GenericName=Secret Sharing
+Comment=End-to-end encrypted secret sharing
+Exec=${APPIMAGE_PATH}
+Icon=${ICON_VALUE}
+Terminal=false
+Categories=Network;FileTransfer;
+Keywords=secret;encryption;share;vault;
+StartupWMClass=deadrop
+EOF
+
+  update-desktop-database "${DATA_HOME}/applications" >/dev/null 2>&1 || true
+  gtk-update-icon-cache -q -t -f "${DATA_HOME}/icons" >/dev/null 2>&1 || true
+
   echo "deadrop desktop ${TAG} installed to ${APPIMAGE_PATH}"
+  echo "Added to your application menu."
   echo "Unsigned build."
 
   if ! printf '%s' "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then

--- a/cli/install-desktop.sh
+++ b/cli/install-desktop.sh
@@ -23,6 +23,43 @@ case "$OS" in
     ;;
 esac
 
+DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+
+# Teardown lives here as well as in `deadrop desktop uninstall`: installing via
+# curl doesn't get you the CLI, so without this there'd be no way to undo it.
+if [ "${1:-}" = "--uninstall" ]; then
+  REMOVED=0
+  if [ "$OS" = "Darwin" ]; then
+    if [ -d "$APP_PATH" ]; then
+      rm -rf "$APP_PATH"
+      echo "Removed ${APP_PATH}"
+      REMOVED=1
+    fi
+  else
+    for TARGET in "$APPIMAGE_PATH" "${INSTALL_DIR}/.deadrop-desktop.version" \
+                  "${DATA_HOME}/applications/deadrop.desktop"; do
+      if [ -e "$TARGET" ]; then
+        rm -f "$TARGET"
+        echo "Removed ${TARGET}"
+        REMOVED=1
+      fi
+    done
+    # The install picks its icon bucket from the extracted PNG's size, so
+    # sweep every bucket rather than guessing which one it used.
+    for ICON in "${DATA_HOME}"/icons/hicolor/*/apps/deadrop.png; do
+      [ -e "$ICON" ] || continue
+      rm -f "$ICON"
+      echo "Removed ${ICON}"
+      REMOVED=1
+    done
+    update-desktop-database "${DATA_HOME}/applications" >/dev/null 2>&1 || true
+    gtk-update-icon-cache -q -t -f "${DATA_HOME}/icons" >/dev/null 2>&1 || true
+  fi
+
+  [ "$REMOVED" -eq 1 ] || echo "deadrop desktop is not installed."
+  exit 0
+fi
+
 # Finding the right release (deadrop-desktop@* among a releases list shared
 # with the CLI's deadrop@* tags) and then that release's own assets needs
 # real JSON structure, not a flat grep extraction like install.sh does —
@@ -128,7 +165,6 @@ else
 
   # Without a .desktop entry the AppImage never appears in the app menu.
   # Mirrors installDesktopEntry() in cli/lib/update/desktop-entry.ts.
-  DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
   # Largest first — .DirIcon is only a 32x32 symlink.
   ICON_VALUE="$APPIMAGE_PATH"
   ICON_TMP=$(mktemp -d)

--- a/cli/install-desktop.sh
+++ b/cli/install-desktop.sh
@@ -46,16 +46,26 @@ fi
 TAG=$(printf '%s' "$RELEASE" | jq -r '.tag_name')
 
 if [ "$OS" = "Darwin" ]; then
-  ASSET_EXT="dmg"
+  # macOS ships a single universal .dmg — no arch suffix to match on.
+  ASSET_SUFFIX=".dmg"
 else
-  ASSET_EXT="AppImage"
+  # Tauri names Linux bundles `<product>_<version>_<arch>.AppImage`. Match
+  # the arch too: selecting on `.AppImage` alone takes whichever build the
+  # API lists first, which hands an x64 user an aarch64 binary the moment a
+  # second Linux target is published.
+  case "$(uname -m)" in
+    x86_64)        ASSET_SUFFIX="_amd64.AppImage" ;;
+    arm64|aarch64) ASSET_SUFFIX="_aarch64.AppImage" ;;
+    *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+  esac
 fi
 
-ASSET_URL=$(printf '%s' "$RELEASE" | jq -r --arg ext ".$ASSET_EXT" '.assets[] | select(.name | endswith($ext)) | .browser_download_url' | head -1)
-SHA_URL=$(printf '%s' "$RELEASE" | jq -r --arg ext ".$ASSET_EXT.sha256" '.assets[] | select(.name | endswith($ext)) | .browser_download_url' | head -1)
+ASSET_URL=$(printf '%s' "$RELEASE" | jq -r --arg sfx "$ASSET_SUFFIX" '.assets[] | select(.name | endswith($sfx)) | .browser_download_url' | head -1)
+SHA_URL=$(printf '%s' "$RELEASE" | jq -r --arg sfx "${ASSET_SUFFIX}.sha256" '.assets[] | select(.name | endswith($sfx)) | .browser_download_url' | head -1)
 
 if [ -z "$ASSET_URL" ] || [ -z "$SHA_URL" ]; then
-  echo "Could not find a .${ASSET_EXT} (or its checksum) on release ${TAG}" >&2
+  echo "Release ${TAG} publishes no ${ASSET_SUFFIX} build (or its checksum) for $(uname -s)/$(uname -m)" >&2
+  echo "See https://github.com/${REPO}/releases" >&2
   exit 1
 fi
 
@@ -69,7 +79,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-ASSET_PATH="$TMP/deadrop.${ASSET_EXT}"
+ASSET_PATH="$TMP/deadrop${ASSET_SUFFIX}"
 curl -fsSL --progress-bar "$ASSET_URL" -o "$ASSET_PATH"
 curl -fsSL "$SHA_URL" -o "${ASSET_PATH}.sha256" || {
   echo "Could not download checksum for verification" >&2

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -5,6 +5,11 @@ REPO="dallen4/deadrop"
 BINARY="deadrop"
 INSTALL_DIR="${DEADROP_INSTALL_DIR:-$HOME/.local/bin}"
 
+# Overridable so installs can be pointed at a mirror, a staging release, or a
+# local registry; defaults are the real GitHub endpoints.
+RELEASES_API="${DEADROP_RELEASES_API:-https://api.github.com/repos/${REPO}/releases}"
+DOWNLOAD_BASE="${DEADROP_RELEASES_DOWNLOAD_BASE:-https://github.com/${REPO}/releases/download}"
+
 case "$(uname -s)" in
   Darwin) OS="darwin" ;;
   Linux)  OS="linux" ;;
@@ -31,7 +36,7 @@ esac
 # same releases list — /releases/latest can't tell them apart, so fetch the
 # list and take the newest tag that's actually a CLI release. `"deadrop@`
 # (with the trailing `@`) naturally excludes `"deadrop-desktop@`.
-RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases") || {
+RELEASE_JSON=$(curl -fsSL "$RELEASES_API") || {
   echo "No published deadrop release found (or network error)." >&2
   echo "See https://github.com/${REPO}/releases" >&2
   exit 1
@@ -39,7 +44,7 @@ RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases") || {
 TAG=$(printf '%s' "$RELEASE_JSON" | grep -o '"tag_name": *"deadrop@[^"]*"' | head -1 | sed 's/.*"deadrop@\([^"]*\)".*/deadrop@\1/')
 [ -z "$TAG" ] && { echo "Could not determine latest release tag" >&2; exit 1; }
 
-URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY}-${OS}-${ARCH}"
+URL="${DOWNLOAD_BASE}/${TAG}/${BINARY}-${OS}-${ARCH}"
 
 echo "Downloading deadrop ${TAG} (${OS}/${ARCH})..."
 

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -1,5 +1,7 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+# POSIX sh, not bash: the documented install is `curl ... | sh`, and /bin/sh is
+# dash on Debian/Ubuntu. Keep this file free of bashisms.
+set -eu
 
 REPO="dallen4/deadrop"
 BINARY="deadrop"
@@ -75,7 +77,7 @@ mv "$TMP/$BINARY" "$INSTALL_DIR/$BINARY"
 
 echo "deadrop ${TAG} installed to ${INSTALL_DIR}/${BINARY}"
 
-if ! command -v deadrop &>/dev/null; then
+if ! command -v deadrop >/dev/null 2>&1; then
   if [ -t 1 ] && [ -z "${CI:-}" ] && [ -r /dev/tty ]; then
     SHELL_RC=""
     case "${SHELL:-}" in
@@ -85,12 +87,15 @@ if ! command -v deadrop &>/dev/null; then
     esac
     printf "\n%s is not in your PATH. Add it now? [y/N] " "$INSTALL_DIR" >/dev/tty
     read -r REPLY </dev/tty
-    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-      echo "export PATH=\"${INSTALL_DIR}:\$PATH\"" >> "$SHELL_RC"
-      echo "Added to ${SHELL_RC}. Run: source ${SHELL_RC}"
-    else
-      echo "Skipped. Add manually: export PATH=\"${INSTALL_DIR}:\$PATH\""
-    fi
+    case "$REPLY" in
+      [Yy]*)
+        echo "export PATH=\"${INSTALL_DIR}:\$PATH\"" >> "$SHELL_RC"
+        echo "Added to ${SHELL_RC}. Run: source ${SHELL_RC}"
+        ;;
+      *)
+        echo "Skipped. Add manually: export PATH=\"${INSTALL_DIR}:\$PATH\""
+        ;;
+    esac
   else
     echo "${INSTALL_DIR} is not in your PATH."
     echo "Add manually: export PATH=\"${INSTALL_DIR}:\$PATH\""

--- a/cli/lib/auth/cache.ts
+++ b/cli/lib/auth/cache.ts
@@ -28,9 +28,16 @@ function isMissingEntry(err: unknown): boolean {
 // macOS/Windows failures are almost always the user denying the
 // keychain/Credential Manager access prompt. Point at the fix for each,
 // since "install libsecret" is meaningless (and confusing) on a Mac.
+//
+// List every package manager rather than detecting the distro — detection
+// is more code and more ways to be wrong, and naming only apt sends Fedora
+// and Arch users to a command that doesn't exist. Mirrors install.sh.
 function keychainUnavailableMessage(): string {
   if (process.platform === 'linux') {
-    return 'Secure credential storage is unavailable. Install libsecret (e.g. `sudo apt-get install -y libsecret-1-0`) and run `deadrop login` again.';
+    return `Secure credential storage is unavailable. Install libsecret, then run \`deadrop login\` again:
+  Ubuntu/Debian: sudo apt-get install -y libsecret-1-0
+  Fedora/RHEL:   sudo dnf install -y libsecret
+  Arch:          sudo pacman -S libsecret`;
   }
   return 'Secure credential storage is unavailable. If your OS just prompted for keychain access, allow it and run `deadrop login` again.';
 }

--- a/cli/lib/constants.ts
+++ b/cli/lib/constants.ts
@@ -16,7 +16,10 @@ export const BINARY_NAME = 'deadrop';
 // distinguish between them, so callers must fetch the list and filter by
 // tag prefix instead (see cli/lib/update/version.ts's fetchLatestBinaryVersion
 // and cli/lib/update/desktop.ts's fetchLatestDesktopRelease).
-export const GITHUB_RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
+// Overridable for mirrors, staging releases, and the Linux sandbox registry.
+export const GITHUB_RELEASES_URL =
+  process.env.DEADROP_RELEASES_API ||
+  `https://api.github.com/repos/${GITHUB_REPO}/releases`;
 export const NPM_REGISTRY_LATEST_URL =
   'https://registry.npmjs.org/deadrop/latest';
 
@@ -45,4 +48,7 @@ export const resolveReleaseAssetName = (
 };
 
 export const releaseAssetUrl = (tag: string, assetName: string) =>
-  `https://github.com/${GITHUB_REPO}/releases/download/${tag}/${assetName}`;
+  `${
+    process.env.DEADROP_RELEASES_DOWNLOAD_BASE ||
+    `https://github.com/${GITHUB_REPO}/releases/download`
+  }/${tag}/${assetName}`;

--- a/cli/lib/update/desktop-entry.ts
+++ b/cli/lib/update/desktop-entry.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   unlinkSync,
@@ -125,8 +126,21 @@ export function installDesktopEntry(appImagePath: string): void {
   refreshDesktopDatabase();
 }
 
+// The install picks its hicolor bucket from the extracted PNG's own size, so
+// uninstall can't recompute it — sweep every bucket instead.
+function removeIcons(): void {
+  const hicolor = join(dataHome(), 'icons', 'hicolor');
+  if (!existsSync(hicolor)) return;
+
+  for (const bucket of readdirSync(hicolor)) {
+    const icon = join(hicolor, bucket, 'apps', `${ICON_NAME}.png`);
+    if (existsSync(icon)) unlinkSync(icon);
+  }
+}
+
 export function removeDesktopEntry(): void {
   const entry = desktopEntryPath();
   if (existsSync(entry)) unlinkSync(entry);
+  removeIcons();
   refreshDesktopDatabase();
 }

--- a/cli/lib/update/desktop-entry.ts
+++ b/cli/lib/update/desktop-entry.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+
+const ICON_NAME = 'deadrop';
+const ENTRY_NAME = 'deadrop.desktop';
+
+const dataHome = (): string =>
+  process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share');
+
+export const desktopEntryPath = (): string =>
+  join(dataHome(), 'applications', ENTRY_NAME);
+
+const iconPath = (size: number): string =>
+  join(
+    dataHome(),
+    'icons',
+    'hicolor',
+    `${size}x${size}`,
+    'apps',
+    `${ICON_NAME}.png`,
+  );
+
+// Width/height sit at fixed offsets in a PNG's IHDR — enough to pick a
+// hicolor bucket without decoding the image.
+function readSquarePngSize(buf: Buffer): number | null {
+  if (buf.length < 24) return null;
+  if (buf.readUInt32BE(0) !== 0x89504e47) return null;
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  return width === height && width > 0 ? width : null;
+}
+
+// Largest first — `.DirIcon` is only a 32x32 symlink, which looks poor in a
+// launcher. --appimage-extract reads the squashfs directly, so no FUSE.
+const ICON_CANDIDATES = [
+  'usr/share/icons/hicolor/256x256@2/apps/deadrop.png',
+  'usr/share/icons/hicolor/128x128/apps/deadrop.png',
+  '.DirIcon',
+];
+
+function extractIcon(appImagePath: string): Buffer | null {
+  const scratch = mkdtempSync(join(tmpdir(), 'deadrop-icon-'));
+  try {
+    for (const candidate of ICON_CANDIDATES) {
+      try {
+        execFileSync(appImagePath, ['--appimage-extract', candidate], {
+          cwd: scratch,
+          stdio: 'ignore',
+        });
+      } catch {
+        continue;
+      }
+      const extracted = join(scratch, 'squashfs-root', candidate);
+      if (existsSync(extracted)) return readFileSync(extracted);
+    }
+    return null;
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+// Neither tool is guaranteed installed, and the entry is already written by
+// the time we get here — never fatal.
+function refreshDesktopDatabase(): void {
+  const commands: Array<[string, string[]]> = [
+    ['update-desktop-database', [join(dataHome(), 'applications')]],
+    ['gtk-update-icon-cache', ['-q', '-t', '-f', join(dataHome(), 'icons')]],
+  ];
+
+  for (const [bin, args] of commands) {
+    try {
+      execFileSync(bin, args, { stdio: 'ignore' });
+    } catch {
+      // not installed, or nothing to do
+    }
+  }
+}
+
+// Exec must be absolute: ~/.local/bin isn't reliably on PATH, and Exec= is
+// not shell-expanded. StartupWMClass ties the running window back to this
+// entry, without which the app shows up as a second unnamed dock icon.
+function renderEntry(execPath: string, iconValue: string): string {
+  return `[Desktop Entry]
+Type=Application
+Name=deadrop
+GenericName=Secret Sharing
+Comment=End-to-end encrypted secret sharing
+Exec=${execPath}
+Icon=${iconValue}
+Terminal=false
+Categories=Network;FileTransfer;
+Keywords=secret;encryption;share;vault;
+StartupWMClass=deadrop
+`;
+}
+
+// Best-effort: a failure here leaves a runnable AppImage that just isn't in
+// the app menu, which beats failing the install.
+export function installDesktopEntry(appImagePath: string): void {
+  let iconValue = ICON_NAME;
+
+  const icon = extractIcon(appImagePath);
+  if (icon) {
+    const dest = iconPath(readSquarePngSize(icon) ?? 256);
+    mkdirSync(join(dest, '..'), { recursive: true });
+    writeFileSync(dest, icon);
+  } else {
+    iconValue = appImagePath;
+  }
+
+  const entry = desktopEntryPath();
+  mkdirSync(join(entry, '..'), { recursive: true });
+  writeFileSync(entry, renderEntry(appImagePath, iconValue));
+
+  refreshDesktopDatabase();
+}
+
+export function removeDesktopEntry(): void {
+  const entry = desktopEntryPath();
+  if (existsSync(entry)) unlinkSync(entry);
+  refreshDesktopDatabase();
+}

--- a/cli/lib/update/desktop.ts
+++ b/cli/lib/update/desktop.ts
@@ -42,6 +42,21 @@ export type DesktopRelease = {
   assetSha256Url: string;
 };
 
+// Tauri names Linux bundles `<product>_<version>_<arch>.AppImage` — e.g.
+// `deadrop_0.1.0_amd64.AppImage`. Matching on the extension alone picks
+// whichever build the releases API happens to list first, which would hand
+// an x64 user an aarch64 binary as soon as a second Linux target ships.
+const LINUX_APPIMAGE_ARCH: Record<string, string> = {
+  x64: 'amd64',
+  arm64: 'aarch64',
+};
+
+function matchesLinuxAppImage(name: string): boolean {
+  const arch = LINUX_APPIMAGE_ARCH[process.arch];
+  if (!arch) return false;
+  return name.endsWith(`_${arch}.AppImage`);
+}
+
 function getInstalledDesktopVersionMac(): string | null {
   if (!existsSync(DESKTOP_APP_PATH)) return null;
 
@@ -139,7 +154,7 @@ export async function fetchLatestDesktopRelease(): Promise<DesktopRelease | null
     process.platform === 'win32'
       ? a.name.endsWith('-setup.exe')
       : process.platform === 'linux'
-        ? a.name.endsWith('.AppImage')
+        ? matchesLinuxAppImage(a.name)
         : a.name.endsWith('.dmg'),
   );
   const assetSha256 = release.assets.find(

--- a/cli/lib/update/desktop.ts
+++ b/cli/lib/update/desktop.ts
@@ -13,7 +13,11 @@ import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { GITHUB_RELEASES_URL } from 'lib/constants';
 import { fetchExpectedChecksum, verifyChecksum } from './checksum';
-import { installDesktopEntry } from './desktop-entry';
+import {
+  desktopEntryPath,
+  installDesktopEntry,
+  removeDesktopEntry,
+} from './desktop-entry';
 import { downloadWithProgress } from './download';
 
 export const DESKTOP_APP_PATH = '/Applications/deadrop.app';
@@ -279,6 +283,58 @@ export async function installOrUpdateDesktop(
       return installOrUpdateDesktopWindows(release);
     case 'linux':
       return installOrUpdateDesktopLinux(release);
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+export type UninstallResult = { removed: string[]; note?: string };
+
+// Mirrors installOrUpdateDesktopLinux: AppImage, version sidecar, and the
+// desktop entry + icon it registered. Leaving those behind puts a dead
+// launcher in the app menu pointing at a deleted binary.
+function uninstallDesktopLinux(): UninstallResult {
+  const removed: string[] = [];
+
+  for (const path of [LINUX_APPIMAGE_PATH, LINUX_VERSION_FILE]) {
+    if (existsSync(path)) {
+      rmSync(path, { force: true });
+      removed.push(path);
+    }
+  }
+
+  const entry = desktopEntryPath();
+  const hadEntry = existsSync(entry);
+  removeDesktopEntry();
+  if (hadEntry) removed.push(entry);
+
+  return { removed };
+}
+
+function uninstallDesktopMac(): UninstallResult {
+  if (!existsSync(DESKTOP_APP_PATH)) return { removed: [] };
+  rmSync(DESKTOP_APP_PATH, { recursive: true, force: true });
+  return { removed: [DESKTOP_APP_PATH] };
+}
+
+// The NSIS installer owns its own uninstaller and registry entries — running
+// it is the supported path, and second-guessing it would strip the registry
+// keys out from under it.
+function uninstallDesktopWindows(): UninstallResult {
+  return {
+    removed: [],
+    note: 'On Windows, uninstall deadrop desktop from Settings > Apps > Installed apps.',
+  };
+}
+
+export function uninstallDesktop(): UninstallResult {
+  switch (process.platform) {
+    case 'darwin':
+      return uninstallDesktopMac();
+    case 'win32':
+      return uninstallDesktopWindows();
+    case 'linux':
+      return uninstallDesktopLinux();
     default:
       throw new Error(`Unsupported platform: ${process.platform}`);
   }

--- a/cli/lib/update/desktop.ts
+++ b/cli/lib/update/desktop.ts
@@ -13,6 +13,7 @@ import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { GITHUB_RELEASES_URL } from 'lib/constants';
 import { fetchExpectedChecksum, verifyChecksum } from './checksum';
+import { installDesktopEntry } from './desktop-entry';
 import { downloadWithProgress } from './download';
 
 export const DESKTOP_APP_PATH = '/Applications/deadrop.app';
@@ -256,6 +257,9 @@ async function installOrUpdateDesktopLinux(
     // can be on different filesystems, where rename() fails with EXDEV.
     copyFileSync(tmpPath, LINUX_APPIMAGE_PATH);
     writeFileSync(LINUX_VERSION_FILE, release.version);
+
+    // Otherwise the AppImage is runnable but absent from the app menu.
+    installDesktopEntry(LINUX_APPIMAGE_PATH);
   } finally {
     rmSync(scratchDir, { recursive: true, force: true });
   }

--- a/cli/tests/unit/desktop-entry.spec.ts
+++ b/cli/tests/unit/desktop-entry.spec.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  desktopEntryPath,
+  installDesktopEntry,
+  removeDesktopEntry,
+} from 'lib/update/desktop-entry';
+
+describe('desktop entry', () => {
+  let dataHome: string;
+  const original = process.env.XDG_DATA_HOME;
+
+  beforeEach(() => {
+    dataHome = mkdtempSync(join(tmpdir(), 'deadrop-xdg-'));
+    process.env.XDG_DATA_HOME = dataHome;
+  });
+
+  afterEach(() => {
+    rmSync(dataHome, { recursive: true, force: true });
+    if (original === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = original;
+  });
+
+  const read = () => readFileSync(desktopEntryPath(), 'utf-8');
+
+  it('honors XDG_DATA_HOME', () => {
+    expect(desktopEntryPath()).toBe(
+      join(dataHome, 'applications', 'deadrop.desktop'),
+    );
+  });
+
+  it('writes an entry even when icon extraction fails', () => {
+    // Not a real AppImage, so --appimage-extract can't succeed — the entry
+    // must still be written, since a missing icon beats a missing launcher.
+    const appImage = join(dataHome, 'deadrop-desktop.AppImage');
+    installDesktopEntry(appImage);
+
+    const entry = read();
+    expect(entry).toContain('[Desktop Entry]');
+    expect(entry).toContain('Type=Application');
+    expect(entry).toContain(`Exec=${appImage}`);
+    // Falls back to pointing Icon at the AppImage itself.
+    expect(entry).toContain(`Icon=${appImage}`);
+  });
+
+  it('uses an absolute Exec path', () => {
+    const appImage = join(dataHome, 'deadrop-desktop.AppImage');
+    installDesktopEntry(appImage);
+
+    const exec = read()
+      .split('\n')
+      .find((line) => line.startsWith('Exec='))!
+      .slice('Exec='.length);
+
+    expect(exec.startsWith('/')).toBe(true);
+  });
+
+  it('declares exactly one main category', () => {
+    installDesktopEntry(join(dataHome, 'deadrop-desktop.AppImage'));
+
+    const categories = read()
+      .split('\n')
+      .find((line) => line.startsWith('Categories='))!
+      .slice('Categories='.length)
+      .split(';')
+      .filter(Boolean);
+
+    const main = [
+      'AudioVideo', 'Audio', 'Video', 'Development', 'Education',
+      'Game', 'Graphics', 'Network', 'Office', 'Science',
+      'Settings', 'System', 'Utility',
+    ];
+
+    expect(categories.filter((c) => main.includes(c))).toHaveLength(1);
+  });
+
+  it('is idempotent and removable', () => {
+    const appImage = join(dataHome, 'deadrop-desktop.AppImage');
+    installDesktopEntry(appImage);
+    installDesktopEntry(appImage);
+    expect(existsSync(desktopEntryPath())).toBe(true);
+
+    removeDesktopEntry();
+    expect(existsSync(desktopEntryPath())).toBe(false);
+  });
+});

--- a/cli/tests/unit/update-desktop.spec.ts
+++ b/cli/tests/unit/update-desktop.spec.ts
@@ -4,8 +4,10 @@ import {
   parseMountPoint,
 } from 'lib/update/desktop';
 
-const withPlatform = (platform: string) => {
-  vi.stubGlobal('process', { ...process, platform });
+// Linux asset selection is arch-sensitive, so tests must pin arch too —
+// otherwise they pass or fail based on the machine running them.
+const withPlatform = (platform: string, arch: string = 'x64') => {
+  vi.stubGlobal('process', { ...process, platform, arch });
 };
 
 describe('parseMountPoint', () => {
@@ -86,7 +88,7 @@ describe('fetchLatestDesktopRelease', () => {
   });
 
   it('resolves the Linux .AppImage asset', async () => {
-    withPlatform('linux');
+    withPlatform('linux', 'x64');
     stubReleases([
       {
         name: 'deadrop_1.2.0_amd64.AppImage',
@@ -103,6 +105,50 @@ describe('fetchLatestDesktopRelease', () => {
       assetUrl: 'https://example.com/deadrop.AppImage',
       assetSha256Url: 'https://example.com/deadrop.AppImage.sha256',
     });
+  });
+
+  it('picks the AppImage matching this arch, not the first one listed', async () => {
+    withPlatform('linux', 'arm64');
+    stubReleases([
+      {
+        name: 'deadrop_1.2.0_amd64.AppImage',
+        browser_download_url: 'https://example.com/amd64.AppImage',
+      },
+      {
+        name: 'deadrop_1.2.0_amd64.AppImage.sha256',
+        browser_download_url: 'https://example.com/amd64.AppImage.sha256',
+      },
+      {
+        name: 'deadrop_1.2.0_aarch64.AppImage',
+        browser_download_url: 'https://example.com/aarch64.AppImage',
+      },
+      {
+        name: 'deadrop_1.2.0_aarch64.AppImage.sha256',
+        browser_download_url: 'https://example.com/aarch64.AppImage.sha256',
+      },
+    ]);
+
+    await expect(fetchLatestDesktopRelease()).resolves.toEqual({
+      version: '1.2.0',
+      assetUrl: 'https://example.com/aarch64.AppImage',
+      assetSha256Url: 'https://example.com/aarch64.AppImage.sha256',
+    });
+  });
+
+  it('returns null when the release has no build for this arch', async () => {
+    withPlatform('linux', 'arm64');
+    stubReleases([
+      {
+        name: 'deadrop_1.2.0_amd64.AppImage',
+        browser_download_url: 'https://example.com/amd64.AppImage',
+      },
+      {
+        name: 'deadrop_1.2.0_amd64.AppImage.sha256',
+        browser_download_url: 'https://example.com/amd64.AppImage.sha256',
+      },
+    ]);
+
+    await expect(fetchLatestDesktopRelease()).resolves.toBeNull();
   });
 
   it('returns null on an unsupported platform', async () => {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "sync-version": "node scripts/sync-version.js"
   },
   "dependencies": {
     "@clerk/clerk-js": "^6.25.10",

--- a/desktop/scripts/sync-version.js
+++ b/desktop/scripts/sync-version.js
@@ -1,0 +1,88 @@
+// package.json is the only version changesets bumps, but Tauri names every
+// bundle from tauri.conf.json and Cargo owns the other two. Left unsynced they
+// drift silently: release deadrop-desktop@0.2.2 shipped a full set of assets
+// named 0.1.0.
+//
+// Run with --check to fail instead of writing (CI drift guard).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const SOURCE = join(root, 'package.json');
+const TAURI_CONF = join(root, 'src-tauri/tauri.conf.json');
+const CARGO_TOML = join(root, 'src-tauri/Cargo.toml');
+const CARGO_LOCK = join(root, 'src-tauri/Cargo.lock');
+
+// Anchored so they can only ever match the package's own version, never a
+// dependency's.
+const CARGO_TOML_VERSION = /(\[package\][\s\S]*?\nversion = )"[^"]*"/;
+const CARGO_LOCK_VERSION =
+  /(\[\[package\]\]\nname = "deadrop"\nversion = )"[^"]*"/;
+
+const check = process.argv.includes('--check');
+const { version } = JSON.parse(readFileSync(SOURCE, 'utf8'));
+
+if (!version) {
+  console.error('No version field in desktop/package.json');
+  process.exit(1);
+}
+
+const targets = [
+  {
+    path: TAURI_CONF,
+    label: 'tauri.conf.json',
+    read: (text) => JSON.parse(text).version,
+    write: (text) => {
+      const conf = JSON.parse(text);
+      conf.version = version;
+      return JSON.stringify(conf, null, 2) + '\n';
+    },
+  },
+  { path: CARGO_TOML, label: 'Cargo.toml', pattern: CARGO_TOML_VERSION },
+  { path: CARGO_LOCK, label: 'Cargo.lock', pattern: CARGO_LOCK_VERSION },
+];
+
+const drifted = [];
+
+for (const target of targets) {
+  const text = readFileSync(target.path, 'utf8');
+  let current;
+  let next;
+
+  if (target.pattern) {
+    const match = text.match(target.pattern);
+    if (!match) {
+      console.error(`Could not find a version to sync in ${target.label}`);
+      process.exit(1);
+    }
+    current = match[0].slice(match[1].length).replaceAll('"', '');
+    next = text.replace(target.pattern, `$1"${version}"`);
+  } else {
+    current = target.read(text);
+    next = target.write(text);
+  }
+
+  if (current === version) continue;
+
+  drifted.push(`${target.label}: ${current} -> ${version}`);
+  if (!check) writeFileSync(target.path, next);
+}
+
+if (!drifted.length) {
+  console.log(`desktop version ${version} already in sync`);
+  process.exit(0);
+}
+
+const detail = drifted.map((line) => `  ${line}`).join('\n');
+
+if (check) {
+  console.error(
+    `desktop version files are out of sync with package.json (${version}):\n${detail}\n\nRun: pnpm -F desktop sync-version`,
+  );
+  process.exit(1);
+}
+
+console.log(`Synced desktop version to ${version}:\n${detail}`);

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "deadrop"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "keyring",
  "libsql",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadrop"
-version = "0.1.0"
+version = "0.2.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "deadrop"
 version = "0.2.2"
-description = "A Tauri App"
-authors = ["you"]
+description = "End-to-end encrypted secret sharing"
+authors = ["Nieky Allen <nieky.allen@gmail.com>"]
 edition = "2021"
+license = "MIT"
+homepage = "https://deadrop.io"
+repository = "https://github.com/dallen4/deadrop"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "deadrop",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "identifier": "com.deadrop",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,6 +26,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "Utility",
+    "shortDescription": "End-to-end encrypted secret sharing",
+    "longDescription": "Share secrets peer-to-peer with end-to-end encryption. Keys and plaintext never leave your device.",
+    "homepage": "https://deadrop.io",
+    "publisher": "deadrop",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "changeset:publish": "node scripts/changeset-publish.js",
     "changeset:status": "changeset status",
     "postversion": "git push --tags",
-    "prepare": "husky"
+    "prepare": "husky",
+    "sandbox": "pnpm -F tests sandbox"
   },
   "dependencies": {
     "@clerk/clerk-js": "^6.3.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "analyze:dup": "jscpd",
     "analyze:unused": "ts-prune",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && pnpm -F desktop sync-version",
     "changeset:publish": "node scripts/changeset-publish.js",
     "changeset:status": "changeset status",
     "postversion": "git push --tags",

--- a/specs/icon-ratios.md
+++ b/specs/icon-ratios.md
@@ -1,0 +1,52 @@
+# Icon ratios — diagnosis & plan
+
+Deferred behind the Linux setup work. Recording the measurements so they don't
+have to be re-derived.
+
+## Measured state
+
+Every icon in the repo is **100% full-bleed with 0% transparent margin** —
+`desktop/src-tauri/icons/*`, `web/public/icons/*`, and
+`vscode-extension/media/icon.png` are all the same artwork edge to edge.
+
+- Tile: `#1a1b1e` rounded square (matches `manifest.json` `background_color`)
+- Glyph: `#1971c2` (matches `theme_color`)
+- Corners: transparent, so the tile shape is baked into the asset
+- Clean vector source exists: `web/public/icons/handshake-transparent.svg`,
+  512 viewBox (also `desktop/public/handshake.svg`)
+
+## Two defects
+
+**1. macOS icon renders oversized in the Dock.** Apple's convention insets a
+rounded-rect app icon to roughly 824/1024 (~80%) of the canvas, reserving the
+remaining margin for shadow. Ours fills 100%, so deadrop sits visibly larger
+than native neighbours. Confirmed by the user against their own Dock.
+
+**2. Android maskable icons get clipped.** `web/public/manifest.json` declares
+`"purpose": "any maskable"` on a single asset. Those requirements contradict:
+`any` means "render exactly as authored, corners included"; `maskable` means
+"I am full-bleed background, crop me to the platform's shape". Android crops
+maskable icons to a safe zone (the inner 80% circle), so our rounded square
+loses its corners and is then composited inside *another* rounded shape. The
+user's report — "the handshake goes all the way to the edge" — is this.
+
+## Plan
+
+1. **macOS**: regenerate from a 1024 source with the tile at ~824 and
+   transparent margin. `tauri icon` (CLI 2.11.4 is available) regenerates
+   `.icns`/`.ico`/PNG set from one source.
+2. **Maskable**: a *separate* asset — background filling the full square with
+   no corners of our own, glyph confined to the safe zone. The guaranteed
+   region is a centred circle of 80% diameter, so a square glyph inscribed in
+   it is ~56% of canvas. Target the glyph at ~55%.
+3. **Manifest**: split into distinct `"purpose": "any"` and
+   `"purpose": "maskable"` entries rather than one asset claiming both.
+4. Leave the `any` web icons full-bleed — correct for favicons and tabs.
+
+Rasterise from the SVG via Playwright (already a `tests/` devDependency)
+rather than rescaling PNGs, so every size stays crisp.
+
+## Review before overwriting
+
+These are brand assets across web, desktop, and the extension. Generate to a
+scratch directory and get a visual sign-off before replacing anything.

--- a/specs/linux-sandbox-design.md
+++ b/specs/linux-sandbox-design.md
@@ -141,30 +141,30 @@ test and verify; it does not ship.
 ```
 tests/sandbox/
 ├── sandbox                  # bash entrypoint (the only thing a human/agent runs)
-├── README.md
 ├── images/
-│   ├── Containerfile.ubuntu
-│   └── Containerfile.fedora
+│   ├── Containerfile.builder  # the ONLY image with a toolchain
+│   ├── Containerfile.ubuntu   # bare target
+│   └── Containerfile.fedora   # bare target
 ├── lib/
-│   ├── runner.sh            # the ONLY container-aware code
-│   ├── harness.sh           # scenario preamble: env contract + result protocol
-│   ├── assert.sh            # assertion primitives
-│   └── fixture-server.js    # ~30-line static server for the fake release registry
-├── fixtures/
-│   ├── releases.json.tmpl   # canned GitHub releases payload, templated with the live port
-│   ├── deadrop-linux-arm64  # a real, tiny, executable stand-in binary
-│   ├── deadrop-desktop.AppImage  # likewise
-│   └── deadrop.desktop.tmpl # CANDIDATE launcher entry — the thing being experimented on (§8/`60`)
+│   ├── runner.sh            # the ONLY container-aware code; also hosts the registry
+│   ├── harness.sh           # scenario preamble: env contract
+│   └── assert.sh            # assertion primitives + result protocol
 ├── scenarios/
-│   ├── 10-install-cli.sh
-│   ├── 20-install-desktop.sh
-│   ├── 30-config-paths.sh
-│   ├── 40-keychain-degradation.sh
-│   ├── 50-glibc-floor.sh
-│   ├── 60-desktop-integration.sh
-│   └── 70-first-run.sh       # the whole journey in one $HOME
+│   ├── 10-install-cli.sh          # built
+│   ├── 20-install-desktop.sh      # todo
+│   ├── 30-config-paths.sh         # todo
+│   ├── 40-keychain-degradation.sh # todo
+│   ├── 50-glibc-floor.sh          # todo
+│   ├── 60-desktop-integration.sh  # todo
+│   └── 70-first-run.sh            # todo
+├── .work/                   # gitignored — artifacts the builder produced
 └── .logs/                   # gitignored, written every run
 ```
+
+There is no `fixtures/` directory of canned binaries. Artifacts are **built**,
+not committed: the builder emits them into `.work/artifacts/`, which the
+registry then serves. A checked-in stand-in binary would test the download
+plumbing while proving nothing about the thing we actually ship.
 
 Wiring:
 
@@ -180,15 +180,17 @@ Wiring:
 ```bash
 pnpm sandbox doctor                    # verify podman + machine state, print exact fixes
 pnpm sandbox list                      # profiles × scenarios
-pnpm sandbox run                       # full matrix (13 cells)
+pnpm sandbox run                       # full matrix
 pnpm sandbox run --profile fedora
 pnpm sandbox run --scenario install-cli # substring match
-pnpm sandbox affected                  # map `git diff --name-only` → scenarios
-pnpm sandbox shell --profile ubuntu    # interactive container, everything prepared
+pnpm sandbox shell --profile ubuntu    # interactive bare target, registry running
 ```
 
-Flags: `--verbose` (stream everything), `--json` (machine summary), `--live`
-(hit real GitHub instead of fixtures, see §7), `--keep` (don't remove containers).
+Built: `doctor`, `list`, `run`, `shell`, `--profile`, `--scenario`, `--verbose`.
+
+Not yet built: `affected` (map `git diff --name-only` → scenarios), `--json`
+(machine summary), `--live` (real GitHub instead of the local registry, §7),
+`--keep` (leave containers for inspection).
 
 `affected` reads a path → scenario map:
 
@@ -200,35 +202,51 @@ Flags: `--verbose` (stream everything), `--json` (machine summary), `--live`
 | `cli/lib/global-config.ts`, `shared/lib/constants.ts` | `30` |
 | `cli/lib/auth/**` | `40` |
 | `.github/workflows/desktop_publish_workflow.yml` | `50` |
-| `tests/sandbox/fixtures/deadrop.desktop.tmpl` | `60` |
+| `cli/lib/update/desktop-entry.ts` | `60` |
 | `cli/actions/init.ts` | `30`, `70` |
 
 ## 5. Runner mechanics
 
-**Image build bakes dependencies.** `Containerfile.*` copies only
-`pnpm-lock.yaml`, `pnpm-workspace.yaml`, and the workspace `package.json` files,
-then runs `pnpm install --frozen-lockfile --filter cli...`. `cli` declares
-`"shared": "workspace:*"`, so that pulls `cli` + `shared` and skips `web`,
-`desktop`, `worker`, and `vscode-extension` entirely. Layer caching keys this on
-the lockfile, so it only rebuilds when dependencies genuinely change.
+**Build somewhere, install somewhere else.** This separation is the entire
+point, and getting it wrong makes the suite worthless. A user never compiles
+deadrop — they download an artifact built on a GitHub runner and run it on their
+own distro, and the gap between "built there" and "runs here" is exactly the bug
+class this exists to catch. Compiling inside the machine under test resolves
+native modules for that machine and papers over every one of those bugs.
 
-**Source is projected, never bind-mounted.** The working tree is mounted
-read-only at `/src` and `tar`-piped into `/work` excluding `node_modules`,
-`.git`, `dist`, `target`, `.next`, `.logs`. Two reasons: the host's
-`node_modules` holds macOS-arm64 native binaries (`libsql`, `@napi-rs/keyring`,
-`node-datachannel`) that would poison the container, and tar extraction overlays
-without deleting, so the image's baked `node_modules` survives. Side benefit:
-**uncommitted work is testable** without committing.
+Three roles, mirroring the real pipeline:
 
-**Prepare once per profile, isolate per scenario.** One prepare container per
-run per profile projects source and runs `pnpm -F cli build` into a named
-volume. Each scenario then gets its own throwaway `podman run --rm` container
-mounting that volume **read-only**, with a fresh `$HOME`. Every scenario mutates
-only `$HOME` (`~/.local/bin`, `~/.local/share`, keyring state), so this gives
-real isolation where it matters without rebuilding the CLI once per scenario.
+| Role | Image | Has | Plays |
+|---|---|---|---|
+| **Builder** | `ubuntu:24.04` | Node 24, pnpm, bun, projected source | the `ubuntu-24.04-arm` runner in `cli_publish_workflow.yml` |
+| **Registry** | — | static file server on loopback | GitHub Releases |
+| **Target** | `ubuntu:24.04`, `fedora:*` | **nothing** — bare distro | the user's machine |
 
-Containers run `--user sandbox`. Running as root would mask permission problems
-that real users hit.
+The builder runs `pnpm compile` (`cli/scripts/bun-build.ts`) and emits
+`deadrop-linux-<arch>` plus a checksum. Note there is no cross-compilation:
+that script resolves the host's libsql `.node` and targets the host platform
+only, which is why CI builds each target on a native runner and why the builder
+here must be a Linux container rather than the macOS host.
+
+**The target image installs nothing.** No Node, no pnpm, no `node_modules`, no
+repo. Anything pre-installed is an unearned assumption about the user's machine.
+The only thing copied in is the script under test — `install.sh` and
+`install-desktop.sh` are single files. Scenarios that legitimately need a
+runtime (the `npm i -g deadrop` path) install it themselves, as that user would.
+
+**Source is projected into the builder only**, never bind-mounted: the tree is
+mounted read-only at `/src` and `tar`-piped in, excluding `node_modules`,
+`.git`, `dist`, `target`, `.next`. The host's `node_modules` holds macOS-arm64
+native binaries that would poison the build. Side benefit: **uncommitted work is
+testable** without committing, which is the whole reason the builder exists
+rather than just consuming published releases.
+
+`--live` skips the builder entirely and points the target at real GitHub, which
+validates published artifacts instead of working-tree ones. Both matter: the
+builder catches unreleased regressions, `--live` catches bad releases.
+
+Targets run `--user sandbox`. Running as root would mask permission problems
+real users hit.
 
 **The EXDEV mount.** `installOrUpdateDesktopLinux` uses `copyFileSync`, not
 `renameSync`, specifically because `mkdtempSync(tmpdir())` and
@@ -249,36 +267,46 @@ harness and reads a fixed env contract:
 
 | Variable | Meaning |
 |---|---|
-| `SANDBOX_REPO` | projected source root (`/work`) |
-| `SANDBOX_CLI` | built CLI entry (`/work/cli/dist/deadrop.js`) |
-| `SANDBOX_FIXTURES` | fixture directory |
-| `SANDBOX_PROFILE` | `ubuntu` \| `fedora` \| `artifact` (scenario `50` only) |
-| `SANDBOX_GLIBC_FLOOR` | declared compatibility floor, e.g. `2.35` (scenario `50` only) |
+| `SANDBOX_SCRIPTS` | the installers under test, mounted read-only (`/scripts`) |
+| `SANDBOX_PROFILE` | `ubuntu` \| `fedora` |
 | `SANDBOX_PKG_REMOVE` | profile-appropriate removal command (`apt-get remove -y` / `dnf remove -y`) |
+| `DEADROP_RELEASES_API` | registry stand-in for the GitHub releases list |
+| `DEADROP_RELEASES_DOWNLOAD_BASE` | ditto, for asset downloads |
 | `HOME` | fresh, empty, writable |
+
+Note there is no `SANDBOX_REPO` or `SANDBOX_CLI`. A target has no repo and no
+prebuilt CLI — it gets a binary the only way a user does, by installing one.
 
 ```bash
 #!/usr/bin/env bash
-source "$(dirname "$0")/../lib/harness.sh"
+. "$(dirname "$0")/../lib/harness.sh"
 
-scenario "install-cli"
+scenario "10-install-cli"
 
-with_fixture_registry            # starts fixture-server.js, exports the two base URLs
+assert_registry_reachable
 
-run_ok bash "$SANDBOX_REPO/cli/install.sh"
-assert_file_exists "$HOME/.local/bin/deadrop"
-assert_executable  "$HOME/.local/bin/deadrop"
-assert_contains "$LAST_STDOUT" "Checksum verified"
+run_ok bash "$SANDBOX_SCRIPTS/install.sh"
+assert_contains "$LAST_STDOUT$LAST_STDERR" "Checksum verified"
+
+BIN="$HOME/.local/bin/deadrop"
+assert_file_exists "$BIN"
+run_ok "$BIN" --version     # placement proves nothing; running it does
+
+finish
 ```
 
-`assert.sh` primitives: `run_ok`, `run_fails`, `assert_file_exists`,
+`assert.sh` primitives: `run`, `run_ok`, `run_fails`, `assert_file_exists`,
 `assert_executable`, `assert_contains`, `assert_not_contains`, `assert_eq`,
-`skip <reason>`.
+`pass`, `fail`, `skip`.
 
-**Result protocol.** Every assertion writes one tab-delimited line to fd 3:
-`PASS|FAIL|SKIP<TAB>scenario<TAB>message`. The scenario exits nonzero if any
-`FAIL` was emitted. `runner.sh` aggregates. Nothing else about the transport is
-the scenario's business, which is what makes §10 possible.
+**Result protocol.** Every assertion prints one tab-delimited line to stdout
+prefixed `##RESULT`: `##RESULT<TAB>PASS|FAIL|SKIP<TAB>scenario<TAB>message`.
+The scenario exits nonzero if any `FAIL` was emitted; `runner.sh` greps the log
+and aggregates.
+
+Not fd 3, which an earlier draft specified — podman forwards only stdio into a
+container, so a scenario writing to fd 3 dies with `Bad file descriptor`. A
+stdout marker also survives any CI log pipeline unchanged, which §10 needs.
 
 **Profile-conditional strips** use `SANDBOX_PKG_REMOVE` rather than hardcoding a
 package manager, so a scenario that needs `jq` gone works identically on both.
@@ -289,11 +317,16 @@ Live GitHub is a bad dependency here. Unauthenticated API calls are capped at 60
 requests/hour/IP, so a full matrix run is both rate-limited and
 non-deterministic — disqualifying for something agents run repeatedly.
 
-Default runs are **fully offline** against a local fixture registry: a small
-Node static server bound to `127.0.0.1` **inside the scenario's own container**
-(no extra container, no network config). `.sha256` files are generated from the
-fixture payloads at prepare time, so a checksum can never drift out of sync with
-what it describes. `releases.json.tmpl` is rendered with the live port.
+Default runs are **fully offline** against a local registry: a `python3 -m
+http.server` on the **host**, reached from the target at
+`host.containers.internal`. Deliberately not inside the target — a machine
+hosting its own file server is not a bare distro any more, and installing
+python3 there would be an unearned assumption about the user.
+
+It serves what the builder produced: the binary, a `.sha256` generated from
+those exact bytes, a minimal releases list, and a `/tampered` copy with a byte
+appended so the checksum genuinely mismatches. Nothing is checked in, so a
+checksum can never drift from what it describes.
 
 This requires a small **production change** — two env overrides that default to
 exactly today's hardcoded values:
@@ -440,41 +473,29 @@ running system, so a second profile would re-derive an identical answer. It is
 also the most CI-shaped scenario here, since it is a pure post-build property —
 see §10.
 
-### `60-desktop-integration` — launcher entry (experimental)
+### `60-desktop-integration` — launcher entry
 
-**This scenario is a workbench, not a regression guard.** The feature it covers
-does not exist: nothing in `install-desktop.sh` or `installOrUpdateDesktopLinux`
-writes a `.desktop` entry, installs an icon, or refreshes the desktop database.
-Today a Linux "install" places an AppImage in `~/.local/bin` and stops, so the
-user's desktop environment never learns the app exists — no launcher entry, no
-icon, and no way to start it but typing an absolute path, since `~/.local/bin`
-is not reliably on `PATH` (`install-desktop.sh:120` warns about exactly this).
+Reported from the field by an Arch/Wayland user: the app never appeared in the
+launcher. Confirmed and fixed — `cli/lib/update/desktop-entry.ts` and the Linux
+branch of `install-desktop.sh` now write the entry and install the icon. This
+scenario is the regression guard for that, asserting the **installer's real
+output**, not a candidate template.
 
-Reported from the field by an Arch/Wayland user, and the reason this scenario is
-shaped as an experiment: we do not yet know the correct `Exec=` line.
-
-**Phase 1 — validate a candidate (now).** `fixtures/deadrop.desktop.tmpl` holds
-a proposed entry. The scenario renders it against the real install path and
-proves the mechanics headlessly, with no installer changes required:
-
-- `desktop-file-validate` passes (package `desktop-file-utils`, present on both
-  profiles — a real cross-distro packaging check in its own right)
-- `Exec=` is an **absolute** path, not a bare command name
-- Env prefixes, if any, use the spec-legal `env VAR=value /path/to/app` form —
-  `Exec=` is not a shell, so `VAR=value /path` alone is invalid and silently
-  fails to launch in some DEs
-- Icon lands at `~/.local/share/icons/hicolor/128x128/apps/deadrop.png`
-  (source: `desktop/src-tauri/icons/128x128.png`, currently shipped only
-  *inside* the AppImage)
-- `update-desktop-database` and `gtk-update-icon-cache` succeed, and degrade
-  cleanly when absent — neither is guaranteed installed
-
-`pnpm sandbox shell` is the intended loop here: edit the template, re-validate,
-iterate. That is what "try it during troubleshooting" means in practice.
-
-**Phase 2 — flip to a guard (after §13.6).** Once the installer writes the entry,
-the same assertions retarget from the fixture to the installer's real output,
-and the scenario becomes an ordinary regression test.
+- `desktop-file-validate` passes on both profiles (`desktop-file-utils` — a
+  cross-distro packaging check in its own right)
+- `Exec=` is an **absolute** path, not a bare command name. The bundled entry
+  inside the AppImage ships `Exec=deadrop`, which resolves only if
+  `~/.local/bin` is on `PATH` — often it isn't
+- Exactly one main category. `Utility;Security;Network;` declares three, which
+  makes `desktop-file-validate` warn about the app appearing twice in the menu;
+  `Network;FileTransfer;` validates clean
+- Env prefixes, if any, use the spec-legal `env VAR=value /path` form — `Exec=`
+  is not a shell, so a bare `VAR=value /path` is invalid and silently fails in
+  some DEs
+- The icon is the **128 or 256** variant, not `.DirIcon`, which symlinks to the
+  32x32 and looks poor in a launcher
+- `update-desktop-database` and `gtk-update-icon-cache` degrade cleanly when
+  absent — neither is guaranteed installed, and neither should fail an install
 
 **What this cannot answer.** Validity is not rendering. Whether the `Exec=` line
 actually produces a window under Wayland — the `WEBKIT_DISABLE_DMABUF_RENDERER`
@@ -562,10 +583,11 @@ Not built now. Designed for.
 
 Scenarios depend only on the §6 env contract, never on podman. `runner.sh` is
 the sole container-aware file. GitHub's `ubuntu-latest` *is* Linux, so a future
-workflow sets `SANDBOX_REPO` / `SANDBOX_CLI` / `SANDBOX_FIXTURES` / a fresh
-`HOME` and loops the same scenario files unchanged; the `fedora` profile maps to
-the workflow `container:` key. Document this in `tests/CLAUDE.md` so the
-eventual CI work is transcription, not redesign.
+workflow builds the artifact in its own job (which is what `cli_publish_workflow.yml`
+already does), serves it, sets `SANDBOX_SCRIPTS` / the two `DEADROP_RELEASES_*`
+vars / a fresh `HOME`, and loops the same scenario files unchanged; the `fedora`
+profile maps to the workflow `container:` key. Document this in
+`tests/CLAUDE.md` so the eventual CI work is transcription, not redesign.
 
 Two things must hold to keep that true, and both are review criteria:
 
@@ -613,11 +635,10 @@ becomes a blocking CI step, start there — not with the install scenarios.
 
 ## 12. Implementation order
 
-1. `doctor` + `Containerfile.ubuntu` + `runner.sh` prepare step — prove a
-   container can build the CLI from projected source
-2. `harness.sh` / `assert.sh` / fixture registry + the base-URL override (§7)
-3. `10-install-cli` on `ubuntu` — the first real cell, end to end
-4. `Containerfile.fedora` — second profile, same scenario
+1. ~~`doctor`, builder + target images, `runner.sh`~~ — **done**
+2. ~~`harness.sh` / `assert.sh` / registry + the base-URL override (§7)~~ — **done**
+3. ~~`10-install-cli` on `ubuntu`~~ — **done**
+4. ~~`Containerfile.fedora`~~ — **done**, `10` green on both
 5. Scenarios `20`, `30`, `40`
 6. Scenario `50` — independent of everything above; can be pulled earlier if the
    build-runner pin is being touched
@@ -672,6 +693,16 @@ opt-in pre-release signoff and unacceptable as a default.
 Explicitly **not** the same problem as §13.5 — emulating `install.sh` is fine,
 emulating WebKitGTK is not.
 
+**Covers the CLI only. It cannot test the desktop AppImage.** Measured, not
+assumed: an AppImage stamps its own magic (`AI\x02`) into ELF header bytes 8-10,
+and the `binfmt_misc` magic/mask qemu registers for x86-64 requires those bytes
+to be zero. The kernel therefore does not recognise an AppImage as an x86-64
+ELF and refuses to exec it — `cannot execute binary file: Exec format error`,
+on a host where ordinary x86-64 binaries emulate fine. This is structural, not
+a configuration problem, and no amount of qemu tuning fixes it. Consequence:
+running the desktop app on an arm64 host requires a native aarch64 build
+(§13.4). There is no emulated shortcut.
+
 ### 13.3 Architecture-aware desktop asset selection
 
 (CPU architecture — nothing to do with Arch Linux.)
@@ -688,8 +719,12 @@ a regression for every existing Linux desktop user.
 
 Not justified by user demand — Linux desktop is overwhelmingly x86_64, and the
 arm64 Linux story is servers and containers, which is the CLI, which already
-publishes `deadrop-linux-arm64`. It is justified as developer infrastructure:
-without it, 13.5 requires emulating a browser engine.
+publishes `deadrop-linux-arm64`. It is justified as developer infrastructure,
+and after the §13.2 measurement it is the **only** way to run the desktop app
+on an Apple Silicon host at all: emulation is structurally impossible for
+AppImages, so without an aarch64 build no local container will ever launch this
+app. That promotes it from convenience to prerequisite — for §13.5, and for the
+"installed means runnable" bar in §1.
 
 Cost is low. The repo is public, so GitHub's `ubuntu-22.04-arm` hosted runners
 are free, and `desktop_publish_workflow.yml`'s matrix is already parameterized —

--- a/specs/linux-sandbox-design.md
+++ b/specs/linux-sandbox-design.md
@@ -17,6 +17,32 @@ be lifted into a `ubuntu-latest` workflow without a rewrite.
 
 ## 1. Scope (decided — do not expand)
 
+**Installed means runnable.** This is the success criterion for every scenario
+here. A file landing at the right path with the right mode bits is not a
+validated install; the only proof is executing what was installed. Every install
+scenario therefore ends by running its artifact, not by inspecting it.
+
+That is achievable headlessly, because "can it run" and "does it render
+correctly" are different questions. The CLI answers the first directly —
+`deadrop --version` either works on that distro or it does not. The desktop
+AppImage answers it up to the display layer: extract it, confirm the inner ELF
+matches the host architecture, confirm every shared library resolves, then
+execute it with no `DISPLAY` and require that the failure is *"cannot open
+display"* rather than "exec format error" or "library not found". Reaching the
+display layer proves the entire chain beneath it. Only "does it draw the right
+pixels" needs a real compositor, and that is §13.5.
+
+**North star: the full first-run journey**, in one home directory, in order —
+install CLI, configure it, install desktop, run both (§8/`70`).
+
+**Authentication is out of scope.** The journey runs anonymous throughout —
+`deadrop init`, vault creation, and config resolution, with no `deadrop login`.
+Drop and grab both work signed out, so this is the genuine first-run path for
+most users, and it avoids putting real credentials or a login bypass in a test
+container. Consequence: `cli/actions/login.ts` is never exercised here, and the
+missing headless-login path (`open(url)` + a loopback server on port 1337) stays
+a known, deliberate gap.
+
 **In scope: install and setup mechanics.**
 
 - `cli/install.sh` end-to-end
@@ -120,7 +146,8 @@ tests/sandbox/
 │   ├── 30-config-paths.sh
 │   ├── 40-keychain-degradation.sh
 │   ├── 50-glibc-floor.sh
-│   └── 60-desktop-integration.sh
+│   ├── 60-desktop-integration.sh
+│   └── 70-first-run.sh       # the whole journey in one $HOME
 └── .logs/                   # gitignored, written every run
 ```
 
@@ -138,7 +165,7 @@ Wiring:
 ```bash
 pnpm sandbox doctor                    # verify podman + machine state, print exact fixes
 pnpm sandbox list                      # profiles × scenarios
-pnpm sandbox run                       # full matrix (11 cells)
+pnpm sandbox run                       # full matrix (13 cells)
 pnpm sandbox run --profile fedora
 pnpm sandbox run --scenario install-cli # substring match
 pnpm sandbox affected                  # map `git diff --name-only` → scenarios
@@ -159,6 +186,7 @@ Flags: `--verbose` (stream everything), `--json` (machine summary), `--live`
 | `cli/lib/auth/**` | `40` |
 | `.github/workflows/desktop_publish_workflow.yml` | `50` |
 | `tests/sandbox/fixtures/deadrop.desktop.tmpl` | `60` |
+| `cli/actions/init.ts` | `30`, `70` |
 
 ## 5. Runner mechanics
 
@@ -282,11 +310,17 @@ tradeoff, and it is opt-in.
 
 ## 8. Scenario catalog
 
-Eleven cells: five scenarios × two profiles, plus one profile-independent
+Thirteen cells: six scenarios × two profiles, plus one profile-independent
 artifact check (`50`) that runs once per run.
 
 ### `10-install-cli` — `cli/install.sh`
 
+- **The installed binary runs.** `deadrop --version` exits 0 and prints the
+  expected version. This is the assertion that matters — placement and mode bits
+  are necessary, not sufficient. It is also the only check that catches a
+  wrong-libc binary, an unresolvable shared library, or a native module
+  (`libsql`, `@napi-rs/keyring`, `node-datachannel`) that failed to resolve for
+  this platform, none of which are visible from the filesystem
 - Exits 0; binary lands at `$DEADROP_INSTALL_DIR/deadrop`, executable
 - Checksum is verified, and a **tampered** payload aborts nonzero without installing
 - Runs to completion non-interactively (no TTY) without hanging — `install.sh:74`
@@ -301,6 +335,17 @@ artifact check (`50`) that runs once per run.
 
 ### `20-install-desktop` — `install-desktop.sh` + `deadrop desktop install`
 
+- **The installed AppImage runs**, as far as a headless container allows:
+  `--appimage-extract` succeeds (valid AppImage structure), the inner ELF's
+  architecture matches the host, `ldd` reports no unresolved libraries, and
+  executing it with `DISPLAY` unset fails with a *display* error rather than
+  `exec format error` or a missing-library error. That distinction is the whole
+  check — reaching the display layer proves arch, permissions, AppImage
+  structure, and the entire shared-library chain are correct.
+  On arm64 this fails today, correctly: `desktop_publish_workflow.yml` ships no
+  aarch64 build (§11), so there is genuinely nothing an arm64 Linux user could
+  run. That is a finding about the product, not a defect in the sandbox, and it
+  should be reported as a failure rather than skipped
 - AppImage lands at `~/.local/bin/deadrop-desktop.AppImage`, mode `0755`
 - Version sidecar `.deadrop-desktop.version` is written, and
   `getInstalledDesktopVersion()` reads it back correctly
@@ -422,6 +467,31 @@ actually produces a window under Wayland — the `WEBKIT_DISABLE_DMABUF_RENDERER
 compositor and a GPU, which is §13.5. Do not let a green `60` be read as "the
 app launches on Wayland." It means "the entry is well-formed."
 
+### `70-first-run` — the whole journey, one home directory
+
+Scenarios `10`-`60` each run in an isolated container with a clean `$HOME`,
+which is the right default for attribution: a failure names one thing. But no
+real user does one step. They install the CLI, configure it, install the desktop
+app, and run both — in sequence, in the same home directory, where each step
+inherits whatever the previous one left behind.
+
+This scenario runs that sequence in a single container:
+
+1. `install.sh` → run `deadrop --version`
+2. `deadrop init` → a usable config and vault (§13.7)
+3. `install-desktop.sh` → run the AppImage headlessly per §8/`20`
+4. Both binaries coexist in `~/.local/bin`, and the `PATH` guidance printed
+   along the way is consistent rather than contradictory
+
+It exists to catch what isolation hides — ordering effects, one installer
+clobbering another's files, a second `PATH` warning that contradicts the first,
+and config written by the CLI that the desktop app cannot read. It is deliberately
+the least isolated thing here, and that is its entire value.
+
+Being a composition, it should be read as a smoke test: when it fails alongside
+a focused scenario, fix the focused one first. When it fails *alone*, the bug is
+in how the steps interact, and that is a class nothing else here can find.
+
 ## 9. Output and exit codes
 
 Quiet by default. One line per cell:
@@ -433,12 +503,14 @@ tests/sandbox › ubuntu
   PASS  30-config-paths             0.6s
   PASS  40-keychain-degradation     1.2s
   PASS  60-desktop-integration      0.5s
+  PASS  70-first-run                4.9s
 
 tests/sandbox › fedora
   PASS  10-install-cli              2.0s
   PASS  20-install-desktop          3.6s
   PASS  30-config-paths             0.7s
   PASS  60-desktop-integration      0.5s
+  PASS  70-first-run                5.1s
   FAIL  40-keychain-degradation     1.1s
         assert_contains: expected stderr to name a fedora-installable package
         got: "Secure credential storage is unavailable. Install libsecret
@@ -450,7 +522,7 @@ tests/sandbox › fedora
 tests/sandbox › artifact
   PASS  50-glibc-floor              0.4s
 
-10 passed, 1 failed (11 cells, 15.9s)
+12 passed, 1 failed (13 cells, 25.9s)
 ```
 
 Failures print the assertion plus its immediate context and nothing else. Full
@@ -537,7 +609,9 @@ becomes a blocking CI step, start there — not with the install scenarios.
 7. Scenario `60` — also independent, and worth pulling forward while the field
    report is fresh; it is the workbench for §13.6 rather than a guard on
    existing behavior
-8. `affected`, `--json`, docs in `tests/CLAUDE.md`, pointers in root and
+8. Scenario `70` — last, since it composes the others; needs §13.7 to get past
+   `deadrop init`
+9. `affected`, `--json`, docs in `tests/CLAUDE.md`, pointers in root and
    `cli/CLAUDE.md`
 
 Step 3 is the checkpoint worth pausing at. If a scenario at that point is not
@@ -610,7 +684,7 @@ guard on the Linux system-dependencies step to cover both runners. Keep the
 
 ### 13.5 GUI profile
 
-A separate opt-in profile, never part of the 11-cell matrix — this is an
+A separate opt-in profile, never part of the 13-cell matrix — this is an
 experimentation shell, not a test suite, and the headless suite's speed is a
 feature worth protecting.
 
@@ -672,3 +746,19 @@ one is its own defect. Items 1-4 above are not blocked by this — only the exac
 Worth separating two symptoms that arrived described as one: an app missing from
 the launcher (items 1-3) and an app that launches but renders blank (the env
 prefix). They have different fixes and can occur independently.
+
+### 13.7 Non-interactive `deadrop init`
+
+`cli/actions/init.ts:41` calls Inquirer's `confirm()` to ask about updating
+`.gitignore`, with no flag to answer it in advance. In a non-TTY environment
+there is nothing to read from, so `init` cannot complete unattended — it blocks
+§8/`70` step 2, and it blocks every real user scripting a setup: Dockerfiles,
+CI, provisioning, devcontainers.
+
+Add `--yes` (and honor `CI`), matching the non-TTY guard `install.sh:74` already
+implements correctly for its own prompt. That script is the in-repo precedent
+for how this should behave.
+
+Not Linux-specific — it fails identically on macOS in a non-TTY shell. It
+surfaced here only because this is the first thing that ever tried to run the
+setup path unattended.

--- a/specs/linux-sandbox-design.md
+++ b/specs/linux-sandbox-design.md
@@ -1,0 +1,674 @@
+# Linux sandbox — design & handoff spec
+
+Goal: a local, containerized way to **actually install and set up** deadrop on
+Linux, so OS-specific install mechanics are exercised during development instead
+of discovered by users.
+
+We already have CI runners that compile and distribute Linux artifacts. Nothing
+currently *installs* them. Everything works well on macOS because macOS is where
+the install paths get run by hand; Linux is buggy because it is only ever built
+and shipped. This closes that gap.
+
+Not a pipeline blocker. This is a developer/agent tool for experimentation and
+pre-release signoff, deliberately shaped so the same scenario scripts can later
+be lifted into a `ubuntu-latest` workflow without a rewrite.
+
+---
+
+## 1. Scope (decided — do not expand)
+
+**In scope: install and setup mechanics.**
+
+- `cli/install.sh` end-to-end
+- `cli/install-desktop.sh` end-to-end
+- `deadrop desktop install` / `deadrop update` (`cli/lib/update/desktop.ts`)
+- Config path resolution (`cli/lib/global-config.ts`)
+- Keychain **degradation** behavior (`cli/lib/auth/cache.ts`)
+- Desktop integration — the freedesktop `.desktop` launcher entry and icon,
+  which **do not exist yet** (§8/`60`, §13.6)
+
+**Out of scope:**
+
+- Rust toolchain, Tauri builds, any desktop compilation
+- GUI, Xvfb, launching the AppImage's window (deferred to §13.5, not permanently
+  excluded)
+- WebRTC drop/grab flows (owned by `tests/e2e/`, and P2P ICE does not complete
+  in Linux containers anyway — see the note in `.github/workflows/cli_e2e_workflow.yml`)
+- x86_64 by default — arm64-native only, with emulation as an opt-in follow-on
+  (§11, §13.2)
+
+**Critical-only assertion bar.** A scenario fails when the user ends up with no
+working tool, a silently broken one, or instructions that are actively wrong.
+Wording, timing, ordering, and non-blocking warnings are not failures. Resist
+adding cosmetic assertions; this suite loses its value the moment it goes red
+for reasons nobody needs to act on.
+
+## 2. Runtime and profiles (decided)
+
+**Podman**, rootless, arm64-native. Chosen over Docker Desktop for licensing and
+for being closest to how GitHub's Linux runners behave.
+
+**Profiles cover variation axes, not distros.** This distinction drives every
+decision below. There are far too many distros to enumerate, but only a handful
+of properties can actually break a setup path:
+
+| Axis | Values that matter | How it is covered |
+|---|---|---|
+| Package manager | apt / dnf / pacman | `ubuntu` + `fedora`. pacman adds no third failure mode — see below |
+| libc | glibc / musl | glibc only. musl is **not supported** today (§11), not merely untested |
+| glibc version | at the build floor / newer | scenario `50`, statically — **no profile needed** |
+| Secret Service | present / absent | runtime strip inside any profile (§6) |
+| Architecture | x86_64 / aarch64 | aarch64 native; x86_64 opt-in (§13.2) |
+
+Only two of those axes need a distinct base image:
+
+| Profile | Base image | Axis it exists for |
+|---|---|---|
+| `ubuntu` | `ubuntu:24.04` | apt family — Ubuntu, Debian, Mint, Pop!_OS |
+| `fedora` | current stable (pin at implementation time, e.g. `fedora:43`) | dnf/rpm family, SELinux enforcing — Fedora, RHEL, CentOS Stream, Rocky |
+
+The glibc-floor axis deliberately does **not** get an `ubuntu:22.04` profile. The
+failure it guards against is a dynamic-linker error at launch on a user's older
+machine, and that is detectable by reading required version symbols out of the
+artifact rather than by running it somewhere old (§8/`50`). Static inspection is
+instant, needs no display, and works on any host architecture. A dedicated
+old-glibc image would add marginal fidelity for the cost of a third profile.
+
+There is no third "barebones" image. "No `jq`, no `libsecret`, no keyring
+daemon" is a **runtime strip** inside either profile (§6), so missing-tooling
+guards get proven on both package families rather than on one synthetic distro.
+
+**Why no `arch` profile**, despite Arch being common among exactly our audience
+(developers on Framework-class hardware): it adds almost no technical coverage.
+It is glibc, `ldconfig -p` works, and XDG paths are identical — the only new
+axis is a third package-manager name, and that surfaces the *same* defect
+`fedora` already catches in §8/`40`. The correct response to three package
+families is not three profiles; it is to stop hardcoding one package manager in
+remediation text (§13.1). `install.sh:18-20` already gets this right by listing
+apt, dnf, and pacman variants together.
+
+Both images contain: bash, curl, node (matching `.nvmrc`, >= 24), pnpm, `jq`,
+`libsecret`, `desktop-file-utils` (for §8/`60`), `binutils` (for §8/`50`), and a
+non-root `sandbox` user with a real home directory. Scenarios that need
+something absent remove it themselves.
+
+## 3. Location and files
+
+Lives in the **existing `tests/` workspace**, not a new package. Its purpose is
+test and verify; it does not ship.
+
+```
+tests/sandbox/
+├── sandbox                  # bash entrypoint (the only thing a human/agent runs)
+├── README.md
+├── images/
+│   ├── Containerfile.ubuntu
+│   └── Containerfile.fedora
+├── lib/
+│   ├── runner.sh            # the ONLY container-aware code
+│   ├── harness.sh           # scenario preamble: env contract + result protocol
+│   ├── assert.sh            # assertion primitives
+│   └── fixture-server.js    # ~30-line static server for the fake release registry
+├── fixtures/
+│   ├── releases.json.tmpl   # canned GitHub releases payload, templated with the live port
+│   ├── deadrop-linux-arm64  # a real, tiny, executable stand-in binary
+│   ├── deadrop-desktop.AppImage  # likewise
+│   └── deadrop.desktop.tmpl # CANDIDATE launcher entry — the thing being experimented on (§8/`60`)
+├── scenarios/
+│   ├── 10-install-cli.sh
+│   ├── 20-install-desktop.sh
+│   ├── 30-config-paths.sh
+│   ├── 40-keychain-degradation.sh
+│   ├── 50-glibc-floor.sh
+│   └── 60-desktop-integration.sh
+└── .logs/                   # gitignored, written every run
+```
+
+Wiring:
+
+- `tests/package.json` gains `"sandbox": "./sandbox/sandbox"`
+- root `package.json` gains `"sandbox": "pnpm -F tests sandbox"`
+- `.gitignore` gains `tests/sandbox/.logs/`
+- Docs go in `tests/CLAUDE.md` as a new section — **no new nested CLAUDE.md**
+- Discovery pointers get added to root `CLAUDE.md` and `cli/CLAUDE.md`, since an
+  agent editing `cli/install.sh` has no reason to open `tests/CLAUDE.md` on its own
+
+## 4. Interface
+
+```bash
+pnpm sandbox doctor                    # verify podman + machine state, print exact fixes
+pnpm sandbox list                      # profiles × scenarios
+pnpm sandbox run                       # full matrix (11 cells)
+pnpm sandbox run --profile fedora
+pnpm sandbox run --scenario install-cli # substring match
+pnpm sandbox affected                  # map `git diff --name-only` → scenarios
+pnpm sandbox shell --profile ubuntu    # interactive container, everything prepared
+```
+
+Flags: `--verbose` (stream everything), `--json` (machine summary), `--live`
+(hit real GitHub instead of fixtures, see §7), `--keep` (don't remove containers).
+
+`affected` reads a path → scenario map:
+
+| Path | Scenarios |
+|---|---|
+| `cli/install.sh` | `10` |
+| `cli/install-desktop.sh` | `20` |
+| `cli/lib/update/**` | `20` |
+| `cli/lib/global-config.ts`, `shared/lib/constants.ts` | `30` |
+| `cli/lib/auth/**` | `40` |
+| `.github/workflows/desktop_publish_workflow.yml` | `50` |
+| `tests/sandbox/fixtures/deadrop.desktop.tmpl` | `60` |
+
+## 5. Runner mechanics
+
+**Image build bakes dependencies.** `Containerfile.*` copies only
+`pnpm-lock.yaml`, `pnpm-workspace.yaml`, and the workspace `package.json` files,
+then runs `pnpm install --frozen-lockfile --filter cli...`. `cli` declares
+`"shared": "workspace:*"`, so that pulls `cli` + `shared` and skips `web`,
+`desktop`, `worker`, and `vscode-extension` entirely. Layer caching keys this on
+the lockfile, so it only rebuilds when dependencies genuinely change.
+
+**Source is projected, never bind-mounted.** The working tree is mounted
+read-only at `/src` and `tar`-piped into `/work` excluding `node_modules`,
+`.git`, `dist`, `target`, `.next`, `.logs`. Two reasons: the host's
+`node_modules` holds macOS-arm64 native binaries (`libsql`, `@napi-rs/keyring`,
+`node-datachannel`) that would poison the container, and tar extraction overlays
+without deleting, so the image's baked `node_modules` survives. Side benefit:
+**uncommitted work is testable** without committing.
+
+**Prepare once per profile, isolate per scenario.** One prepare container per
+run per profile projects source and runs `pnpm -F cli build` into a named
+volume. Each scenario then gets its own throwaway `podman run --rm` container
+mounting that volume **read-only**, with a fresh `$HOME`. Every scenario mutates
+only `$HOME` (`~/.local/bin`, `~/.local/share`, keyring state), so this gives
+real isolation where it matters without rebuilding the CLI once per scenario.
+
+Containers run `--user sandbox`. Running as root would mask permission problems
+that real users hit.
+
+**The EXDEV mount.** `installOrUpdateDesktopLinux` uses `copyFileSync`, not
+`renameSync`, specifically because `mkdtempSync(tmpdir())` and
+`~/.local/bin` can be on different filesystems (`cli/lib/update/desktop.ts:240`).
+In a stock container `/tmp` and `$HOME` are both on the same overlayfs, so that
+path is **never exercised** — the regression would pass silently. Scenario 20
+therefore runs with `--tmpfs /mnt/alt:rw,exec,size=256m` and `TMPDIR=/mnt/alt`,
+forcing a genuine cross-filesystem copy.
+
+Note the same concern does *not* apply to `install.sh` or `install-desktop.sh`:
+both use shell `mv`, which falls back to copy+unlink across devices. Only
+Node's `rename(2)` fails with `EXDEV`. Do not "fix" the shell scripts.
+
+## 6. Scenario contract
+
+A scenario is plain bash that knows nothing about containers. It sources the
+harness and reads a fixed env contract:
+
+| Variable | Meaning |
+|---|---|
+| `SANDBOX_REPO` | projected source root (`/work`) |
+| `SANDBOX_CLI` | built CLI entry (`/work/cli/dist/deadrop.js`) |
+| `SANDBOX_FIXTURES` | fixture directory |
+| `SANDBOX_PROFILE` | `ubuntu` \| `fedora` \| `artifact` (scenario `50` only) |
+| `SANDBOX_GLIBC_FLOOR` | declared compatibility floor, e.g. `2.35` (scenario `50` only) |
+| `SANDBOX_PKG_REMOVE` | profile-appropriate removal command (`apt-get remove -y` / `dnf remove -y`) |
+| `HOME` | fresh, empty, writable |
+
+```bash
+#!/usr/bin/env bash
+source "$(dirname "$0")/../lib/harness.sh"
+
+scenario "install-cli"
+
+with_fixture_registry            # starts fixture-server.js, exports the two base URLs
+
+run_ok bash "$SANDBOX_REPO/cli/install.sh"
+assert_file_exists "$HOME/.local/bin/deadrop"
+assert_executable  "$HOME/.local/bin/deadrop"
+assert_contains "$LAST_STDOUT" "Checksum verified"
+```
+
+`assert.sh` primitives: `run_ok`, `run_fails`, `assert_file_exists`,
+`assert_executable`, `assert_contains`, `assert_not_contains`, `assert_eq`,
+`skip <reason>`.
+
+**Result protocol.** Every assertion writes one tab-delimited line to fd 3:
+`PASS|FAIL|SKIP<TAB>scenario<TAB>message`. The scenario exits nonzero if any
+`FAIL` was emitted. `runner.sh` aggregates. Nothing else about the transport is
+the scenario's business, which is what makes §10 possible.
+
+**Profile-conditional strips** use `SANDBOX_PKG_REMOVE` rather than hardcoding a
+package manager, so a scenario that needs `jq` gone works identically on both.
+
+## 7. Fixture registry and the base-URL override
+
+Live GitHub is a bad dependency here. Unauthenticated API calls are capped at 60
+requests/hour/IP, so a full matrix run is both rate-limited and
+non-deterministic — disqualifying for something agents run repeatedly.
+
+Default runs are **fully offline** against a local fixture registry: a small
+Node static server bound to `127.0.0.1` **inside the scenario's own container**
+(no extra container, no network config). `.sha256` files are generated from the
+fixture payloads at prepare time, so a checksum can never drift out of sync with
+what it describes. `releases.json.tmpl` is rendered with the live port.
+
+This requires a small **production change** — two env overrides that default to
+exactly today's hardcoded values:
+
+| Variable | Default |
+|---|---|
+| `DEADROP_RELEASES_API` | `https://api.github.com/repos/dallen4/deadrop/releases` |
+| `DEADROP_RELEASES_DOWNLOAD_BASE` | `https://github.com/dallen4/deadrop/releases/download` |
+
+Applied at five call sites:
+
+- `cli/install.sh:34` — releases list URL → `DEADROP_RELEASES_API`
+- `cli/install.sh:42` — asset URL → `DEADROP_RELEASES_DOWNLOAD_BASE`
+- `cli/install-desktop.sh:33` — releases list URL → `DEADROP_RELEASES_API`
+- `cli/lib/constants.ts:19` (`GITHUB_RELEASES_URL`) → `DEADROP_RELEASES_API`
+- `cli/lib/constants.ts:47` (`releaseAssetUrl`) → `DEADROP_RELEASES_DOWNLOAD_BASE`
+
+`install-desktop.sh` and `fetchLatestDesktopRelease` resolve their download URLs
+from the payload's `browser_download_url`, so they need only the API override —
+the fixture JSON carries local URLs directly.
+
+This has independent production value beyond the sandbox: mirrored/self-hosted
+installs, air-gapped environments, and validating against a staging release
+before tagging.
+
+`--live` runs the identical scenarios against real GitHub for pre-release
+signoff. Expect it to be slower and occasionally rate-limited; that is the
+tradeoff, and it is opt-in.
+
+## 8. Scenario catalog
+
+Eleven cells: five scenarios × two profiles, plus one profile-independent
+artifact check (`50`) that runs once per run.
+
+### `10-install-cli` — `cli/install.sh`
+
+- Exits 0; binary lands at `$DEADROP_INSTALL_DIR/deadrop`, executable
+- Checksum is verified, and a **tampered** payload aborts nonzero without installing
+- Runs to completion non-interactively (no TTY) without hanging — `install.sh:74`
+  guards the `read` behind `[ -t 1 ]`, `-z "${CI:-}"`, and `-r /dev/tty`; all
+  three must hold, and the sandbox is a realistic place for that to regress
+- Prints the manual PATH instruction when `~/.local/bin` is not on `PATH`
+- The libsecret probe (`install.sh:14-21`) does not misfire on either profile.
+  Note this script already prints correct apt/dnf/pacman variants — it is the
+  Node-side message that does not (see scenario 40)
+- `bash` is a hard dependency (`[[ =~ ]]`, `set -o pipefail`); asserted
+  explicitly so it stays a known, documented requirement
+
+### `20-install-desktop` — `install-desktop.sh` + `deadrop desktop install`
+
+- AppImage lands at `~/.local/bin/deadrop-desktop.AppImage`, mode `0755`
+- Version sidecar `.deadrop-desktop.version` is written, and
+  `getInstalledDesktopVersion()` reads it back correctly
+- **EXDEV**: with `TMPDIR` on a separate tmpfs, `deadrop desktop install`
+  succeeds (the copy-not-rename regression guard)
+- Re-running updates in place without corrupting or duplicating the install
+- With `jq` removed, `install-desktop.sh` exits 1 with the actionable message at
+  `install-desktop.sh:29` — not a stack trace, not a silent partial install
+- Both the shell script and the Node command land the app in the same place
+- **Asset selection is architecture-aware.** The fixture release carries *both* an
+  amd64 and an aarch64 AppImage, and the container's own architecture's build
+  must be the one installed. This fails today: `cli/lib/update/desktop.ts:142`
+  matches `a.name.endsWith('.AppImage')` and `install-desktop.sh:54` does
+  `select(.name | endswith($ext)) | head -1` — neither filters on architecture,
+  so with two Linux AppImages on one release the winner is whichever the API
+  lists first. It is latent only because `desktop_publish_workflow.yml` ships a
+  single Linux target (§13.4). The CLI path does not share the flaw;
+  `resolveReleaseAssetName()` (`cli/lib/constants.ts:34`) builds an explicit
+  `deadrop-linux-<arch>` name. **Fix this before adding a second Linux desktop
+  build**, or existing x64 users get handed an aarch64 binary.
+
+### `30-config-paths` — `cli/lib/global-config.ts`
+
+- Default resolves to `~/.local/share/<APP_IDENTIFIER>`
+- `XDG_DATA_HOME` is honored when set
+- CLI and desktop agree on one vault directory (the stated reason this function
+  mirrors Tauri's `app_data_dir()`), so a vault created by one is visible to the
+  other
+- `deadrop init` in a clean `$HOME` produces a usable config and a working
+  SQLite database — this is where a mis-resolved native `libsql` binding
+  surfaces on Linux
+
+### `40-keychain-degradation` — `cli/lib/auth/cache.ts`
+
+Degradation only. The full gnome-keyring roundtrip is deliberately excluded:
+making `dbus-run-session` + an unlocked daemon reliable in a container is the
+single most fragile thing this suite could contain, and it tests a happy path,
+not a critical error.
+
+- With libsecret removed: `getToken()` returns `''` and never throws
+  (`cache.ts:42`), the process warns once and continues, and an anonymous drop
+  still works end-to-end
+- `setSession()` (login) surfaces a real error rather than faking success
+  (`cache.ts:112`)
+- **The remediation text is distro-appropriate.** `cache.ts:33` hardcodes
+  ``sudo apt-get install -y libsecret-1-0``. On Fedora that command does not
+  exist and the package is `libsecret` — a user following our own error message
+  gets a second error. This assertion fails on `fedora` on day one; that is the
+  point, and it is the concrete thing that justifies a second profile.
+
+### `50-glibc-floor` — artifact compatibility floor (profile-independent)
+
+Guards the pin at `desktop_publish_workflow.yml:28-32`, which builds the
+AppImage on `ubuntu-22.04` specifically so the result links against an older
+glibc and stays loadable on more end-user distros.
+
+Nothing today notices if that pin changes. Bumping it to `ubuntu-latest` still
+produces a green build and a published release; the binary then requires newer
+`GLIBC_` symbols and dies in the dynamic linker on every Ubuntu 22.04, Debian
+12, and RHEL 9 machine, before a single line of app code runs. It is the
+canonical "we build on Linux but never set up on Linux" failure.
+
+The check needs no execution and no old base image:
+
+1. `--appimage-extract` the artifact
+2. For every ELF in the extracted tree, read required version symbols
+   (`readelf --version-info`, or `objdump -T`)
+3. Assert the maximum `GLIBC_x.y` is at or below the declared floor
+
+The floor is declared once as `SANDBOX_GLIBC_FLOOR` (2.35 for `ubuntu-22.04`)
+and must be updated deliberately, in the same commit that changes the build
+runner. That coupling is the actual guard — the assertion exists to make a
+silent change loud.
+
+Runs once per run rather than per profile: it inspects a build artifact, not a
+running system, so a second profile would re-derive an identical answer. It is
+also the most CI-shaped scenario here, since it is a pure post-build property —
+see §10.
+
+### `60-desktop-integration` — launcher entry (experimental)
+
+**This scenario is a workbench, not a regression guard.** The feature it covers
+does not exist: nothing in `install-desktop.sh` or `installOrUpdateDesktopLinux`
+writes a `.desktop` entry, installs an icon, or refreshes the desktop database.
+Today a Linux "install" places an AppImage in `~/.local/bin` and stops, so the
+user's desktop environment never learns the app exists — no launcher entry, no
+icon, and no way to start it but typing an absolute path, since `~/.local/bin`
+is not reliably on `PATH` (`install-desktop.sh:120` warns about exactly this).
+
+Reported from the field by an Arch/Wayland user, and the reason this scenario is
+shaped as an experiment: we do not yet know the correct `Exec=` line.
+
+**Phase 1 — validate a candidate (now).** `fixtures/deadrop.desktop.tmpl` holds
+a proposed entry. The scenario renders it against the real install path and
+proves the mechanics headlessly, with no installer changes required:
+
+- `desktop-file-validate` passes (package `desktop-file-utils`, present on both
+  profiles — a real cross-distro packaging check in its own right)
+- `Exec=` is an **absolute** path, not a bare command name
+- Env prefixes, if any, use the spec-legal `env VAR=value /path/to/app` form —
+  `Exec=` is not a shell, so `VAR=value /path` alone is invalid and silently
+  fails to launch in some DEs
+- Icon lands at `~/.local/share/icons/hicolor/128x128/apps/deadrop.png`
+  (source: `desktop/src-tauri/icons/128x128.png`, currently shipped only
+  *inside* the AppImage)
+- `update-desktop-database` and `gtk-update-icon-cache` succeed, and degrade
+  cleanly when absent — neither is guaranteed installed
+
+`pnpm sandbox shell` is the intended loop here: edit the template, re-validate,
+iterate. That is what "try it during troubleshooting" means in practice.
+
+**Phase 2 — flip to a guard (after §13.6).** Once the installer writes the entry,
+the same assertions retarget from the fixture to the installer's real output,
+and the scenario becomes an ordinary regression test.
+
+**What this cannot answer.** Validity is not rendering. Whether the `Exec=` line
+actually produces a window under Wayland — the `WEBKIT_DISABLE_DMABUF_RENDERER`
+/ `WEBKIT_DISABLE_COMPOSITING_MODE` / `GDK_BACKEND` question — needs a real
+compositor and a GPU, which is §13.5. Do not let a green `60` be read as "the
+app launches on Wayland." It means "the entry is well-formed."
+
+## 9. Output and exit codes
+
+Quiet by default. One line per cell:
+
+```
+tests/sandbox › ubuntu
+  PASS  10-install-cli              1.9s
+  PASS  20-install-desktop          3.4s
+  PASS  30-config-paths             0.6s
+  PASS  40-keychain-degradation     1.2s
+  PASS  60-desktop-integration      0.5s
+
+tests/sandbox › fedora
+  PASS  10-install-cli              2.0s
+  PASS  20-install-desktop          3.6s
+  PASS  30-config-paths             0.7s
+  PASS  60-desktop-integration      0.5s
+  FAIL  40-keychain-degradation     1.1s
+        assert_contains: expected stderr to name a fedora-installable package
+        got: "Secure credential storage is unavailable. Install libsecret
+              (e.g. `sudo apt-get install -y libsecret-1-0`) and run
+              `deadrop login` again."
+        → cli/lib/auth/cache.ts:33  keychainUnavailableMessage()
+        log: tests/sandbox/.logs/2026-08-09T14-22-03/fedora/40-keychain-degradation.log
+
+tests/sandbox › artifact
+  PASS  50-glibc-floor              0.4s
+
+10 passed, 1 failed (11 cells, 15.9s)
+```
+
+Failures print the assertion plus its immediate context and nothing else. Full
+logs are **always** written for deliberate grepping, pass or fail. `--verbose`
+streams everything; `--json` emits a machine-readable summary.
+
+Exit codes: `0` all passed · `1` a scenario failed (a real code problem) · `2`
+environment problem (podman missing, machine stopped, image build failed). The
+`1`/`2` split matters — an agent must never report a broken container runtime as
+a product bug.
+
+`doctor` and every exit-`2` path print the exact fix, never a stack trace:
+
+```
+podman machine is not running.
+  Fix: podman machine start
+```
+
+## 10. CI graduation path
+
+Not built now. Designed for.
+
+Scenarios depend only on the §6 env contract, never on podman. `runner.sh` is
+the sole container-aware file. GitHub's `ubuntu-latest` *is* Linux, so a future
+workflow sets `SANDBOX_REPO` / `SANDBOX_CLI` / `SANDBOX_FIXTURES` / a fresh
+`HOME` and loops the same scenario files unchanged; the `fedora` profile maps to
+the workflow `container:` key. Document this in `tests/CLAUDE.md` so the
+eventual CI work is transcription, not redesign.
+
+Two things must hold to keep that true, and both are review criteria:
+
+1. No scenario shells out to `podman`, or references image or volume names
+2. No scenario assumes it can `sudo` (CI runners can; we run as `sandbox`
+   precisely so nothing starts depending on root)
+
+Scenario `50` is the natural first graduation candidate, and the one place a
+pipeline gate would be clearly warranted rather than merely possible. It is a
+pure post-build artifact property, needs no container at all, and the failure it
+catches ships silently to every user on an older distro. If any of this ever
+becomes a blocking CI step, start there — not with the install scenarios.
+
+## 11. Deferred, with reasons
+
+- **musl / Alpine.** Dropped when the matrix narrowed to the two most common
+  distro families. This costs coverage of the `@libsql/linux-arm64-musl`
+  optional-dependency path, and of a **suspected live bug**: `install.sh:15` runs
+  `ldconfig -p | grep -q libsecret-1`, but musl's `ldconfig` does not implement
+  `-p`. Under `set -euo pipefail` with `if !`, that plausibly makes the script
+  claim libsecret is missing on Alpine even when it is installed. Unverified —
+  worth a scenario if Alpine ever becomes a supported target.
+- **x64.** Everything runs native arm64; emulated x64 was excluded for speed and
+  fidelity. This lands differently for the two products. The CLI publishes both
+  `deadrop-linux-x64` and `deadrop-linux-arm64`
+  (`cli_publish_workflow.yml:27,30`), so scenarios 10/30/40 exercise a genuine
+  arm64 artifact and the x64 twin simply goes untested. The desktop app
+  publishes **only** `Linux (x86_64 AppImage)`
+  (`desktop_publish_workflow.yml:31`) — there is no aarch64 build at all, so
+  under `--live` on an arm64 host scenario 20 installs a foreign-arch AppImage.
+  That remains a valid test, because scenario 20 asserts placement, permissions,
+  sidecar, and EXDEV behavior and never executes the binary. It stops being
+  valid the moment anything tries to launch it (§13.5).
+- **gnome-keyring happy path.** See §8/`40`. If it is ever wanted, it belongs in
+  its own scenario that can be skipped, not folded into the degradation tests —
+  and §13's GUI profile is the natural home for it, since a real desktop session
+  starts D-Bus and the keyring daemon properly.
+- **Windows.** `install-desktop.sh:18` exits pointing at `deadrop desktop
+  install`, and a native `install-desktop.ps1` remains an untracked fast-follow.
+  Out of scope here entirely.
+- **AppImage execution.** We assert placement, permissions, and (statically)
+  link compatibility, but never launch. A real launch needs FUSE and a display —
+  that is §13.5, and it is a different kind of tool: an experimentation shell,
+  not a test.
+
+## 12. Implementation order
+
+1. `doctor` + `Containerfile.ubuntu` + `runner.sh` prepare step — prove a
+   container can build the CLI from projected source
+2. `harness.sh` / `assert.sh` / fixture registry + the base-URL override (§7)
+3. `10-install-cli` on `ubuntu` — the first real cell, end to end
+4. `Containerfile.fedora` — second profile, same scenario
+5. Scenarios `20`, `30`, `40`
+6. Scenario `50` — independent of everything above; can be pulled earlier if the
+   build-runner pin is being touched
+7. Scenario `60` — also independent, and worth pulling forward while the field
+   report is fresh; it is the workbench for §13.6 rather than a guard on
+   existing behavior
+8. `affected`, `--json`, docs in `tests/CLAUDE.md`, pointers in root and
+   `cli/CLAUDE.md`
+
+Step 3 is the checkpoint worth pausing at. If a scenario at that point is not
+obviously portable to a bare `ubuntu-latest` runner, the abstraction is wrong
+and §10 is already lost.
+
+None of §13 is in this order. The headless suite ships first and is blocked on
+nothing below.
+
+## 13. Sequenced follow-ons
+
+Each is independently justified and independently shippable. The ordering is a
+dependency chain, not a wishlist.
+
+### 13.1 Package-manager-agnostic remediation text
+
+`cli/lib/auth/cache.ts:33` hardcodes ``sudo apt-get install -y libsecret-1-0``.
+That advice is wrong on Fedora (`libsecret`, via dnf) and wrong on Arch
+(`libsecret`, via pacman) — a user following our own error message hits a second
+error. Scenario `40` fails on the `fedora` profile from day one because of this;
+this is the fix that turns it green.
+
+Do what `install.sh:18-20` already does and name all three, rather than
+detecting the distro. Detection is more code and more ways to be wrong, and the
+message is short enough to list variants inline.
+
+Cheap, no dependencies, and it is the one confirmed user-facing Linux bug this
+design surfaced before writing a line of sandbox code.
+
+### 13.2 Opt-in emulated x86_64
+
+The default matrix is arm64-native, which is fast and matches the development
+machine. It does not match most Linux users, and it categorically does not match
+desktop: `desktop_publish_workflow.yml` ships x86_64 **only** (§11).
+
+Add `--arch amd64`, running the same profiles and scenarios under
+`podman --platform linux/amd64` with qemu. Scenarios are already architecture-
+agnostic bash, so this costs a runner flag rather than new test code. Expect
+roughly 5-10x slowdown; for install mechanics (curl, chmod, file placement, a
+short Node process) that is a minutes-long full pass, which is acceptable for
+opt-in pre-release signoff and unacceptable as a default.
+
+Explicitly **not** the same problem as §13.5 — emulating `install.sh` is fine,
+emulating WebKitGTK is not.
+
+### 13.3 Architecture-aware desktop asset selection
+
+(CPU architecture — nothing to do with Arch Linux.)
+
+See §8/`20`. `cli/lib/update/desktop.ts:142` and `install-desktop.sh:54` select
+the first `.AppImage` on a release without filtering by architecture. Harmless
+while exactly one Linux desktop build exists; ships an aarch64 binary to x64
+users the moment a second one does.
+
+**This is a hard prerequisite for 13.4.** Adding the build first would introduce
+a regression for every existing Linux desktop user.
+
+### 13.4 aarch64 Linux AppImage build
+
+Not justified by user demand — Linux desktop is overwhelmingly x86_64, and the
+arm64 Linux story is servers and containers, which is the CLI, which already
+publishes `deadrop-linux-arm64`. It is justified as developer infrastructure:
+without it, 13.5 requires emulating a browser engine.
+
+Cost is low. The repo is public, so GitHub's `ubuntu-22.04-arm` hosted runners
+are free, and `desktop_publish_workflow.yml`'s matrix is already parameterized —
+it is one added row plus widening the `if: matrix.runner == 'ubuntu-22.04'`
+guard on the Linux system-dependencies step to cover both runners. Keep the
+22.04 glibc pin for the same compatibility reason documented at line 28.
+
+### 13.5 GUI profile
+
+A separate opt-in profile, never part of the 11-cell matrix — this is an
+experimentation shell, not a test suite, and the headless suite's speed is a
+feature worth protecting.
+
+Shape: Xvfb + a lightweight window manager + x11vnc + noVNC, so the app is
+reachable over Screen Sharing (`vnc://localhost:5900`) or a browser
+(`localhost:6080`). Launch via `--appimage-extract-and-run` to avoid needing
+`/dev/fuse` and `CAP_SYS_ADMIN`, which keeps the container rootless and
+consistent with §5. Requires the full WebKitGTK/GTK3/libayatana dependency set
+already enumerated in `desktop_publish_workflow.yml`'s Linux setup step.
+
+Once 13.4 lands this runs native on arm64. Attempting it before then means
+emulating WebKitGTK under qemu, which is frequently slow to the point of
+unusable and sometimes crashes outright — worth an experiment, not worth
+designing around.
+
+This is where the gnome-keyring happy path deferred in §8/`40` belongs: a real
+desktop session starts D-Bus and the keyring daemon properly, so what was
+prohibitively fragile in a bare container becomes straightforward here.
+
+It is also the only place the `Exec=` line from §13.6 can be confirmed to
+actually render a window rather than merely parse.
+
+### 13.6 Linux desktop integration
+
+Independent of 13.1-13.5 and shippable at any point; numbered last only to avoid
+renumbering cross-references, not because it ranks last. Arguably the highest
+user-visible impact of anything here — it is the difference between the desktop
+app being installed and being merely downloaded.
+
+Reported by a Linux user, confirmed absent: `grep` across `cli/` and `desktop/`
+finds no `.desktop`, no `hicolor`, no `xdg-desktop-menu`, and no
+`update-desktop-database`. The only matches are macOS `/Applications` paths.
+
+Both Linux install paths need to gain, alongside placing the AppImage:
+
+1. `~/.local/share/applications/deadrop.desktop` — `Type=Application`, absolute
+   `Exec=`, `Icon=deadrop`, `Terminal=false`, sensible `Categories=`
+2. The icon at `~/.local/share/icons/hicolor/128x128/apps/deadrop.png`, sourced
+   from `desktop/src-tauri/icons/128x128.png`
+3. A best-effort `update-desktop-database` / `gtk-update-icon-cache` refresh that
+   does not fail the install when those binaries are missing
+4. A removal path — nothing currently uninstalls anything, and writing files into
+   shared XDG directories without a way to remove them is worse than not writing
+   them
+
+Keep both implementations in sync: `install-desktop.sh` and
+`installOrUpdateDesktopLinux` (`cli/lib/update/desktop.ts:229`) are already
+parallel implementations of the same install, and this doubles the surface where
+they can drift.
+
+**Open question, blocking the `Exec=` line only.** Whether the entry needs a
+WebKitGTK env prefix under Wayland is unresolved. The candidates are
+`WEBKIT_DISABLE_DMABUF_RENDERER=1` (blank window on WebKitGTK 2.42+),
+`WEBKIT_DISABLE_COMPOSITING_MODE=1`, and `GDK_BACKEND=x11` as a blunt fallback.
+Which applies depends on GPU, driver, and compositor, and baking in the wrong
+one is its own defect. Items 1-4 above are not blocked by this — only the exact
+`Exec=` value is.
+
+Worth separating two symptoms that arrived described as one: an app missing from
+the launcher (items 1-3) and an app that launches but renders blank (the env
+prefix). They have different fixes and can occur independently.

--- a/specs/linux-sandbox-design.md
+++ b/specs/linux-sandbox-design.md
@@ -9,6 +9,19 @@ currently *installs* them. Everything works well on macOS because macOS is where
 the install paths get run by hand; Linux is buggy because it is only ever built
 and shipped. This closes that gap.
 
+Three purposes, in priority order:
+
+1. **Simulate user setup** — run the real install and configuration path a user
+   runs, on a clean machine, and prove it works
+2. **Exercise practical usage** — confirm what was installed actually runs, not
+   merely that files landed
+3. **Reproduce bugs** — when a Linux user reports something, get a disposable
+   machine matching their setup and reproduce it locally rather than guessing
+
+The third is why `shell` and `--keep` (§4) are first-class rather than debug
+conveniences, and why profiles are cheap to add: a repro harness is only useful
+if you can quickly shape it to match the reporter's environment.
+
 Not a pipeline blocker. This is a developer/agent tool for experimentation and
 pre-release signoff, deliberately shaped so the same scenario scripts can later
 be lifted into a `ubuntu-latest` workflow without a rewrite.
@@ -56,8 +69,10 @@ a known, deliberate gap.
 **Out of scope:**
 
 - Rust toolchain, Tauri builds, any desktop compilation
-- GUI, Xvfb, launching the AppImage's window (deferred to §13.5, not permanently
-  excluded)
+- Any display stack, and therefore rendering. The AppImage *is* executed
+  (headlessly, per "installed means runnable" above); what is out of scope is
+  drawing a window and judging what it looks like — deferred to §13.5, not
+  permanently excluded
 - WebRTC drop/grab flows (owned by `tests/e2e/`, and P2P ICE does not complete
   in Linux containers anyway — see the note in `.github/workflows/cli_e2e_workflow.yml`)
 - x86_64 by default — arm64-native only, with emulation as an opt-in follow-on
@@ -688,9 +703,21 @@ A separate opt-in profile, never part of the 13-cell matrix — this is an
 experimentation shell, not a test suite, and the headless suite's speed is a
 feature worth protecting.
 
-Shape: Xvfb + a lightweight window manager + x11vnc + noVNC, so the app is
-reachable over Screen Sharing (`vnc://localhost:5900`) or a browser
-(`localhost:6080`). Launch via `--appimage-extract-and-run` to avoid needing
+**It must be Wayland, not X11.** With `DISPLAY` set and `WAYLAND_DISPLAY` unset,
+GTK selects its X11 backend, so an Xvfb-based profile would not reproduce a
+Wayland-specific WebKitGTK fault — it would report a confident pass on exactly
+the bug it exists to investigate. Use a headless Wayland compositor
+(`weston --backend=headless-backend.so`, or `sway` under `WLR_BACKENDS=headless`)
+with `wayvnc`, reachable over Screen Sharing at `vnc://localhost:5900`. Keep an
+XWayland path available for comparison, since running both is how you establish
+whether a fault is backend-specific at all.
+
+Fidelity caveat: if the underlying fault is in the DMABUF renderer it is likely
+GPU- and driver-dependent, and a container falling back to software rendering
+may not reproduce it under any compositor. Treat this profile as a strong lead,
+not a verdict.
+
+Launch via `--appimage-extract-and-run` to avoid needing
 `/dev/fuse` and `CAP_SYS_ADMIN`, which keeps the container rootless and
 consistent with §5. Requires the full WebKitGTK/GTK3/libayatana dependency set
 already enumerated in `desktop_publish_workflow.yml`'s Linux setup step.

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "test:e2e": "pnpm -F cli build && vitest run -c vitest.e2e.config.mts",
-    "test:e2e:run": "vitest run -c vitest.e2e.config.mts"
+    "test:e2e:run": "vitest run -c vitest.e2e.config.mts",
+    "sandbox": "./sandbox/sandbox"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/tests/sandbox/images/Containerfile.builder
+++ b/tests/sandbox/images/Containerfile.builder
@@ -1,0 +1,32 @@
+# Plays the ubuntu-24.04-arm runner from cli_publish_workflow.yml. The only
+# image here with a toolchain — targets stay bare.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive HUSKY=0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash ca-certificates curl git unzip xz-utils python3 build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
+
+WORKDIR /build
+
+# Manifests only, so the dependency layer is keyed on the lockfile. Source
+# arrives at run time via tar, which adds without deleting.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY cli/package.json cli/
+COPY shared/package.json shared/
+COPY worker/package.json worker/
+COPY web/package.json web/
+COPY desktop/package.json desktop/
+COPY vscode-extension/package.json vscode-extension/
+COPY tests/package.json tests/
+
+RUN pnpm install --frozen-lockfile --filter cli...

--- a/tests/sandbox/images/Containerfile.fedora
+++ b/tests/sandbox/images/Containerfile.fedora
@@ -1,0 +1,11 @@
+# See Containerfile.ubuntu — same "bare user machine" rule, dnf/rpm family.
+FROM fedora:43
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+      bash ca-certificates curl file jq \
+      libsecret desktop-file-utils binutils \
+    && dnf clean all
+
+RUN useradd --create-home --shell /bin/bash sandbox
+USER sandbox
+WORKDIR /home/sandbox

--- a/tests/sandbox/images/Containerfile.ubuntu
+++ b/tests/sandbox/images/Containerfile.ubuntu
@@ -1,0 +1,20 @@
+# A user's machine, not a dev box. Deliberately has no Node, no pnpm, no
+# toolchain — only what a stock desktop install ships. Anything added here is
+# an assumption about the user we haven't earned.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# curl + ca-certificates: install.sh's only hard prerequisites.
+# jq: install-desktop.sh guards on it, and scenarios strip it to prove that.
+# libsecret-1-0: present on a normal desktop; scenarios remove it to test
+# keychain degradation.
+# desktop-file-utils: validates the .desktop entry we write.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash ca-certificates curl file jq \
+      libsecret-1-0 desktop-file-utils binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash sandbox
+USER sandbox
+WORKDIR /home/sandbox

--- a/tests/sandbox/lib/assert.sh
+++ b/tests/sandbox/lib/assert.sh
@@ -1,0 +1,67 @@
+# Assertions emit one tab-delimited, prefixed line on stdout. Not fd 3:
+# podman forwards only stdio into a container, and a stdout marker also
+# survives any CI log pipeline unchanged.
+
+SANDBOX_FAILURES=0
+SANDBOX_RESULT_PREFIX="##RESULT"
+
+_emit() {
+  printf '%s\t%s\t%s\t%s\n' "$SANDBOX_RESULT_PREFIX" "$1" "${SANDBOX_SCENARIO:-?}" "$2"
+}
+
+scenario() { SANDBOX_SCENARIO="$1"; }
+pass() { _emit PASS "$1"; }
+fail() { SANDBOX_FAILURES=$((SANDBOX_FAILURES + 1)); _emit FAIL "$1"; }
+skip() { _emit SKIP "$1"; }
+
+# Captures output without aborting — the scenario decides what a nonzero exit
+# means.
+run() {
+  LAST_STDOUT=$("$@" 2>/tmp/sandbox-stderr) && LAST_STATUS=0 || LAST_STATUS=$?
+  LAST_STDERR=$(cat /tmp/sandbox-stderr)
+  return 0
+}
+
+run_ok() {
+  run "$@"
+  if [ "$LAST_STATUS" -eq 0 ]; then
+    pass "$1 exited 0"
+  else
+    fail "$1 exited $LAST_STATUS: ${LAST_STDERR:-$LAST_STDOUT}"
+  fi
+}
+
+run_fails() {
+  run "$@"
+  if [ "$LAST_STATUS" -ne 0 ]; then
+    pass "$1 exited $LAST_STATUS as expected"
+  else
+    fail "$1 unexpectedly succeeded"
+  fi
+}
+
+assert_file_exists() {
+  if [ -f "$1" ]; then pass "$1 exists"; else fail "$1 missing"; fi
+}
+
+assert_executable() {
+  if [ -x "$1" ]; then pass "$1 executable"; else fail "$1 not executable"; fi
+}
+
+assert_contains() {
+  case "$1" in
+    *"$2"*) pass "output contains '$2'" ;;
+    *) fail "expected '$2' in: $(printf '%s' "$1" | tr '\n' ' ' | head -c 300)" ;;
+  esac
+}
+
+assert_not_contains() {
+  case "$1" in
+    *"$2"*) fail "did not expect '$2' in output" ;;
+    *) pass "output omits '$2'" ;;
+  esac
+}
+
+assert_eq() {
+  if [ "$1" = "$2" ]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi
+}

--- a/tests/sandbox/lib/harness.sh
+++ b/tests/sandbox/lib/harness.sh
@@ -2,12 +2,19 @@
 # unchanged on a bare Linux CI runner.
 #
 # Contract, all set by the runner:
+#   SANDBOX_MODE                    local | released
 #   SANDBOX_SCRIPTS                 install.sh / install-desktop.sh under test
 #   SANDBOX_PROFILE                 ubuntu | fedora
 #   SANDBOX_PKG_REMOVE              profile-appropriate removal command
+#   HOME                            fresh and writable
+#
+# local mode additionally sets, pointing at the on-host registry:
 #   DEADROP_RELEASES_API            registry stand-in for GitHub Releases
 #   DEADROP_RELEASES_DOWNLOAD_BASE  ditto, for asset downloads
-#   HOME                            fresh and writable
+#
+# released mode sets neither, so the scripts fall back to their own GitHub
+# defaults, and adds:
+#   SANDBOX_PUBLIC_BASE             where users are told to curl the scripts from
 #
 # The registry runs outside the machine under test — a target that had to host
 # its own file server wouldn't be a bare distro any more.
@@ -15,17 +22,50 @@
 set -u
 
 : "${SANDBOX_SCRIPTS:?not set}"
-: "${DEADROP_RELEASES_API:?not set}"
-: "${DEADROP_RELEASES_DOWNLOAD_BASE:?not set}"
+: "${SANDBOX_MODE:?not set}"
+
+if [ "$SANDBOX_MODE" = "local" ]; then
+  : "${DEADROP_RELEASES_API:?not set}"
+  : "${DEADROP_RELEASES_DOWNLOAD_BASE:?not set}"
+else
+  : "${SANDBOX_PUBLIC_BASE:?not set}"
+fi
 
 # shellcheck source=./assert.sh
 . "$(dirname "${BASH_SOURCE[0]}")/assert.sh"
 
+released_mode() { [ "$SANDBOX_MODE" = "released" ]; }
+
+# The script a user would actually run. local mode reads the working tree so
+# unreleased changes are testable; released mode curls the published copy, which
+# is the only way to catch a script that is fine in-repo but broken as served.
+install_script() {
+  local name="$1"
+  if released_mode; then
+    local dest="/tmp/published-$name"
+    if [ ! -f "$dest" ]; then
+      curl -fsSL "$SANDBOX_PUBLIC_BASE/$name" -o "$dest" || {
+        fail "could not download $SANDBOX_PUBLIC_BASE/$name"
+        return 1
+      }
+    fi
+    printf '%s' "$dest"
+  else
+    printf '%s' "$SANDBOX_SCRIPTS/$name"
+  fi
+}
+
 assert_registry_reachable() {
-  if curl -fsS "$DEADROP_RELEASES_API" -o /dev/null 2>&1; then
+  local url
+  if released_mode; then
+    url="$SANDBOX_PUBLIC_BASE/install.sh"
+  else
+    url="$DEADROP_RELEASES_API"
+  fi
+  if curl -fsS "$url" -o /dev/null 2>&1; then
     pass "registry reachable"
   else
-    fail "registry unreachable at $DEADROP_RELEASES_API"
+    fail "registry unreachable at $url"
   fi
 }
 

--- a/tests/sandbox/lib/harness.sh
+++ b/tests/sandbox/lib/harness.sh
@@ -1,0 +1,35 @@
+# Sourced by every scenario. Knows nothing about podman, so these scripts run
+# unchanged on a bare Linux CI runner.
+#
+# Contract, all set by the runner:
+#   SANDBOX_SCRIPTS                 install.sh / install-desktop.sh under test
+#   SANDBOX_PROFILE                 ubuntu | fedora
+#   SANDBOX_PKG_REMOVE              profile-appropriate removal command
+#   DEADROP_RELEASES_API            registry stand-in for GitHub Releases
+#   DEADROP_RELEASES_DOWNLOAD_BASE  ditto, for asset downloads
+#   HOME                            fresh and writable
+#
+# The registry runs outside the machine under test — a target that had to host
+# its own file server wouldn't be a bare distro any more.
+
+set -u
+
+: "${SANDBOX_SCRIPTS:?not set}"
+: "${DEADROP_RELEASES_API:?not set}"
+: "${DEADROP_RELEASES_DOWNLOAD_BASE:?not set}"
+
+# shellcheck source=./assert.sh
+. "$(dirname "${BASH_SOURCE[0]}")/assert.sh"
+
+assert_registry_reachable() {
+  if curl -fsS "$DEADROP_RELEASES_API" -o /dev/null 2>&1; then
+    pass "registry reachable"
+  else
+    fail "registry unreachable at $DEADROP_RELEASES_API"
+  fi
+}
+
+finish() {
+  [ "$SANDBOX_FAILURES" -eq 0 ] || exit 1
+  exit 0
+}

--- a/tests/sandbox/lib/runner.sh
+++ b/tests/sandbox/lib/runner.sh
@@ -1,0 +1,154 @@
+# The only container-aware file. Scenarios depend on the env contract in
+# harness.sh, never on podman, so they lift onto a bare CI runner unchanged.
+
+SANDBOX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SANDBOX_DIR/../.." && pwd)"
+WORK="$SANDBOX_DIR/.work"
+LOGS="$SANDBOX_DIR/.logs"
+
+BUILDER_IMAGE="deadrop-sandbox-builder"
+TARGET_IMAGE_PREFIX="deadrop-sandbox"
+
+# Dummy values: install mechanics never reach the network beyond the registry,
+# but cli/scripts/bun-build.ts hard-exits without these.
+BUILD_ENV=(
+  -e HUSKY=0
+  -e DEADROP_API_URL=http://127.0.0.1:9/api
+  -e DEADROP_APP_URL=http://127.0.0.1:9
+  -e PEER_SERVER_URL=http://127.0.0.1:9/peers
+  -e CLERK_PUBLISHABLE_KEY=pk_test_sandbox
+  -e TURN_USERNAME=sandbox
+  -e TURN_PWD=sandbox
+)
+
+die() { printf '%s\n' "$*" >&2; exit 2; }
+
+# Pin every build and run to the host arch — a base image cached from an
+# emulated pull would otherwise be picked up silently.
+host_platform() {
+  case "$(podman info --format '{{.Host.Arch}}')" in
+    arm64|aarch64) printf 'linux/arm64' ;;
+    *) printf 'linux/amd64' ;;
+  esac
+}
+
+doctor() {
+  command -v podman >/dev/null 2>&1 || die "podman is not installed.
+  Fix: brew install podman"
+
+  podman machine inspect >/dev/null 2>&1 || die "no podman machine.
+  Fix: podman machine init --cpus 4 --memory 4096 --disk-size 40"
+
+  podman info >/dev/null 2>&1 || die "podman machine is not running.
+  Fix: podman machine start"
+
+  printf 'podman %s, machine running, arch %s\n' \
+    "$(podman version --format '{{.Client.Version}}')" \
+    "$(podman info --format '{{.Host.Arch}}')"
+}
+
+build_image() {
+  local name="$1" file="$2"
+  podman build -q --platform "$(host_platform)" -t "$name" \
+    -f "$SANDBOX_DIR/images/$file" "$REPO_ROOT" \
+    >/dev/null || die "image build failed: $file"
+}
+
+# Produces the artifacts a release would, in a container with a toolchain —
+# never in the one under test.
+build_artifacts() {
+  local arch artifact
+  arch=$(podman info --format '{{.Host.Arch}}')
+  [ "$arch" = "arm64" ] && arch=arm64 || arch=x64
+  artifact="deadrop-linux-${arch}"
+
+  rm -rf "$WORK/artifacts"
+  mkdir -p "$WORK/artifacts/download/deadrop@0.0.0-sandbox" \
+           "$WORK/artifacts/tampered/deadrop@0.0.0-sandbox"
+
+  build_image "$BUILDER_IMAGE" Containerfile.builder
+
+  podman run --rm --platform "$(host_platform)" "${BUILD_ENV[@]}" \
+    -v "$REPO_ROOT:/src:ro" \
+    -v "$WORK/artifacts/download/deadrop@0.0.0-sandbox:/out" \
+    "$BUILDER_IMAGE" bash -c '
+      set -euo pipefail
+      cd /src
+      tar -cf - --exclude=node_modules --exclude=.git --exclude=dist \
+                --exclude=.next --exclude=target . | (cd /build && tar -xf -)
+      cd /build/cli
+      pnpm compile >/dev/null
+      cp dist/deadrop /out/'"$artifact"'
+      cd /out && sha256sum '"$artifact"' > '"$artifact"'.sha256
+    ' || die "artifact build failed"
+
+  # Same bytes with one flipped, so the checksum genuinely mismatches.
+  cp "$WORK/artifacts/download/deadrop@0.0.0-sandbox/$artifact.sha256" \
+     "$WORK/artifacts/tampered/deadrop@0.0.0-sandbox/"
+  cp "$WORK/artifacts/download/deadrop@0.0.0-sandbox/$artifact" \
+     "$WORK/artifacts/tampered/deadrop@0.0.0-sandbox/"
+  printf 'tampered' >> "$WORK/artifacts/tampered/deadrop@0.0.0-sandbox/$artifact"
+
+  # install.sh greps tag_name out of this, so only that field has to be real.
+  cat > "$WORK/artifacts/releases" <<'JSON'
+[{"tag_name": "deadrop@0.0.0-sandbox", "assets": []}]
+JSON
+
+  ARTIFACT_NAME="$artifact"
+}
+
+# Serves artifacts from the host: a target that hosted its own file server
+# wouldn't be a bare distro any more.
+start_registry() {
+  REGISTRY_PORT=$(awk 'BEGIN{srand();print int(18000+rand()*2000)}')
+  (cd "$WORK/artifacts" && python3 -m http.server "$REGISTRY_PORT" \
+    --bind 127.0.0.1 >/dev/null 2>&1) &
+  REGISTRY_PID=$!
+
+  local i
+  for i in $(seq 1 50); do
+    curl -fsS "http://127.0.0.1:${REGISTRY_PORT}/releases" -o /dev/null 2>/dev/null && return 0
+    sleep 0.1
+  done
+  die "registry failed to start on port $REGISTRY_PORT"
+}
+
+stop_registry() {
+  [ -n "${REGISTRY_PID:-}" ] && kill "$REGISTRY_PID" 2>/dev/null
+  REGISTRY_PID=""
+}
+
+run_scenario() {
+  local profile="$1" scenario="$2" name log
+  name=$(basename "$scenario" .sh)
+  log="$LOGS/$RUN_ID/$profile/$name.log"
+  mkdir -p "$(dirname "$log")"
+
+  local pkg_remove="apt-get remove -y"
+  [ "$profile" = "fedora" ] && pkg_remove="dnf remove -y"
+
+  local base="http://host.containers.internal:${REGISTRY_PORT}"
+  local started ended
+  started=$(date +%s)
+
+  podman run --rm --platform "$(host_platform)" \
+    --user sandbox \
+    -e HOME=/home/sandbox \
+    -e SANDBOX_SCRIPTS=/scripts \
+    -e SANDBOX_PROFILE="$profile" \
+    -e SANDBOX_PKG_REMOVE="$pkg_remove" \
+    -e DEADROP_RELEASES_API="$base/releases" \
+    -e DEADROP_RELEASES_DOWNLOAD_BASE="$base/download" \
+    -v "$REPO_ROOT/cli:/scripts:ro" \
+    -v "$SANDBOX_DIR/lib:/sandbox/lib:ro" \
+    -v "$SANDBOX_DIR/scenarios:/sandbox/scenarios:ro" \
+    "${TARGET_IMAGE_PREFIX}-${profile}" \
+    bash /sandbox/scenarios/"$(basename "$scenario")" \
+    >"$log" 2>&1
+  local status=$?
+  grep '^##RESULT' "$log" > "$log.results" 2>/dev/null || true
+  ended=$(date +%s)
+
+  report_scenario "$profile" "$name" "$status" "$((ended - started))" "$log"
+  return $status
+}

--- a/tests/sandbox/lib/runner.sh
+++ b/tests/sandbox/lib/runner.sh
@@ -6,6 +6,13 @@ REPO_ROOT="$(cd "$SANDBOX_DIR/../.." && pwd)"
 WORK="$SANDBOX_DIR/.work"
 LOGS="$SANDBOX_DIR/.logs"
 
+# local:    build from the working tree, serve from an on-host registry.
+# released: no build, no registry — curl the published scripts and install the
+#           real GitHub release, which is the only way to catch breakage that
+#           exists in what users are served rather than in the working tree.
+SANDBOX_MODE="local"
+SANDBOX_PUBLIC_BASE="${SANDBOX_PUBLIC_BASE:-https://deadrop.io}"
+
 BUILDER_IMAGE="deadrop-sandbox-builder"
 TARGET_IMAGE_PREFIX="deadrop-sandbox"
 
@@ -127,7 +134,19 @@ run_scenario() {
   local pkg_remove="apt-get remove -y"
   [ "$profile" = "fedora" ] && pkg_remove="dnf remove -y"
 
-  local base="http://host.containers.internal:${REGISTRY_PORT}"
+  # released mode deliberately passes no DEADROP_RELEASES_* overrides, so the
+  # scripts use their own GitHub defaults — the real user path.
+  local -a mode_env
+  if [ "$SANDBOX_MODE" = "released" ]; then
+    mode_env=(-e SANDBOX_PUBLIC_BASE="$SANDBOX_PUBLIC_BASE")
+  else
+    local base="http://host.containers.internal:${REGISTRY_PORT}"
+    mode_env=(
+      -e DEADROP_RELEASES_API="$base/releases"
+      -e DEADROP_RELEASES_DOWNLOAD_BASE="$base/download"
+    )
+  fi
+
   local started ended
   started=$(date +%s)
 
@@ -135,10 +154,10 @@ run_scenario() {
     --user sandbox \
     -e HOME=/home/sandbox \
     -e SANDBOX_SCRIPTS=/scripts \
+    -e SANDBOX_MODE="$SANDBOX_MODE" \
     -e SANDBOX_PROFILE="$profile" \
     -e SANDBOX_PKG_REMOVE="$pkg_remove" \
-    -e DEADROP_RELEASES_API="$base/releases" \
-    -e DEADROP_RELEASES_DOWNLOAD_BASE="$base/download" \
+    "${mode_env[@]}" \
     -v "$REPO_ROOT/cli:/scripts:ro" \
     -v "$SANDBOX_DIR/lib:/sandbox/lib:ro" \
     -v "$SANDBOX_DIR/scenarios:/sandbox/scenarios:ro" \

--- a/tests/sandbox/sandbox
+++ b/tests/sandbox/sandbox
@@ -26,6 +26,8 @@ usage: pnpm sandbox <command> [options]
 options:
   --profile <name>      limit to one profile (ubuntu|fedora)
   --scenario <substr>   limit to matching scenarios
+  --released            test the published scripts + live GitHub release
+                        instead of building from the working tree
   --verbose             stream scenario output
 EOF
 }
@@ -78,10 +80,15 @@ cmd_run() {
   doctor >/dev/null
   RUN_ID=$(date +%Y-%m-%dT%H-%M-%S)
 
-  printf 'building artifacts (builder container)...\n'
-  build_artifacts
-  start_registry
-  trap 'stop_registry' EXIT
+  if [ "$SANDBOX_MODE" = "released" ]; then
+    printf 'released mode: %s + live GitHub releases (no local build)\n' \
+      "$SANDBOX_PUBLIC_BASE"
+  else
+    printf 'building artifacts (builder container)...\n'
+    build_artifacts
+    start_registry
+    trap 'stop_registry' EXIT
+  fi
 
   local profile f
   for profile in "${PROFILES[@]}"; do
@@ -100,18 +107,27 @@ cmd_run() {
 cmd_shell() {
   doctor >/dev/null
   local profile="${SELECTED:-ubuntu}"
-  build_artifacts
-  start_registry
-  trap 'stop_registry' EXIT
+  local -a mode_env
+  if [ "$SANDBOX_MODE" = "released" ]; then
+    mode_env=(-e SANDBOX_PUBLIC_BASE="$SANDBOX_PUBLIC_BASE")
+  else
+    build_artifacts
+    start_registry
+    trap 'stop_registry' EXIT
+    local base="http://host.containers.internal:${REGISTRY_PORT}"
+    mode_env=(
+      -e DEADROP_RELEASES_API="$base/releases"
+      -e DEADROP_RELEASES_DOWNLOAD_BASE="$base/download"
+    )
+  fi
   build_image "${TARGET_IMAGE_PREFIX}-${profile}" "Containerfile.${profile}"
 
-  local base="http://host.containers.internal:${REGISTRY_PORT}"
   podman run --rm -it --user sandbox \
     -e HOME=/home/sandbox \
     -e SANDBOX_SCRIPTS=/scripts \
+    -e SANDBOX_MODE="$SANDBOX_MODE" \
     -e SANDBOX_PROFILE="$profile" \
-    -e DEADROP_RELEASES_API="$base/releases" \
-    -e DEADROP_RELEASES_DOWNLOAD_BASE="$base/download" \
+    "${mode_env[@]}" \
     -v "$REPO_ROOT/cli:/scripts:ro" \
     -v "$SANDBOX_DIR/lib:/sandbox/lib:ro" \
     -v "$SANDBOX_DIR/scenarios:/sandbox/scenarios:ro" \
@@ -125,6 +141,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --profile) SELECTED="$2"; PROFILES=("$2"); shift 2 ;;
     --scenario) FILTER="$2"; shift 2 ;;
+    --released) SANDBOX_MODE="released"; shift ;;
     --verbose) VERBOSE=1; shift ;;
     *) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
   esac

--- a/tests/sandbox/sandbox
+++ b/tests/sandbox/sandbox
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Local Linux install/setup sandbox. See specs/linux-sandbox-design.md.
+#
+#   0  all passed
+#   1  a scenario failed (a real code problem)
+#   2  environment problem (podman missing, image build failed)
+set -uo pipefail
+
+SANDBOX_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SANDBOX_DIR/lib/runner.sh"
+
+PROFILES=(ubuntu fedora)
+VERBOSE=0
+FILTER=""
+SELECTED=""
+
+usage() {
+  cat <<'EOF'
+usage: pnpm sandbox <command> [options]
+
+  doctor                verify podman is usable, print exact fixes
+  list                  show profiles and scenarios
+  run                   run the matrix
+  shell                 interactive target container
+
+options:
+  --profile <name>      limit to one profile (ubuntu|fedora)
+  --scenario <substr>   limit to matching scenarios
+  --verbose             stream scenario output
+EOF
+}
+
+PASSED=0
+FAILED=0
+FAILED_NAMES=()
+
+report_scenario() {
+  local profile="$1" name="$2" status="$3" secs="$4" log="$5"
+
+  if [ "$status" -eq 0 ]; then
+    PASSED=$((PASSED + 1))
+    printf '  \033[32mPASS\033[0m  %-28s %ss\n' "$name" "$secs"
+  else
+    FAILED=$((FAILED + 1))
+    FAILED_NAMES+=("$profile/$name")
+    printf '  \033[31mFAIL\033[0m  %-28s %ss\n' "$name" "$secs"
+    # Only the failed assertions, then where to read everything.
+    if [ -f "$log.results" ]; then
+      awk -F'\t' '$2=="FAIL"{printf "        %s\n", $4}' "$log.results"
+    fi
+    printf '        log: %s\n' "${log#"$SANDBOX_DIR/"}"
+  fi
+
+  [ "$VERBOSE" -eq 1 ] && sed 's/^/        | /' "$log"
+  return 0
+}
+
+scenario_files() {
+  local f
+  for f in "$SANDBOX_DIR"/scenarios/*.sh; do
+    [ -f "$f" ] || continue
+    if [ -n "$FILTER" ]; then
+      case "$(basename "$f")" in *"$FILTER"*) ;; *) continue ;; esac
+    fi
+    printf '%s\n' "$f"
+  done
+}
+
+cmd_list() {
+  printf 'profiles:  %s\n' "${PROFILES[*]}"
+  printf 'scenarios:\n'
+  scenario_files | while read -r f; do
+    printf '  %s\n' "$(basename "$f" .sh)"
+  done
+}
+
+cmd_run() {
+  doctor >/dev/null
+  RUN_ID=$(date +%Y-%m-%dT%H-%M-%S)
+
+  printf 'building artifacts (builder container)...\n'
+  build_artifacts
+  start_registry
+  trap 'stop_registry' EXIT
+
+  local profile f
+  for profile in "${PROFILES[@]}"; do
+    build_image "${TARGET_IMAGE_PREFIX}-${profile}" "Containerfile.${profile}"
+    printf '\ntests/sandbox \342\200\272 %s\n' "$profile"
+    while read -r f; do
+      run_scenario "$profile" "$f"
+    done < <(scenario_files)
+  done
+
+  printf '\n%d passed, %d failed\n' "$PASSED" "$FAILED"
+  [ "$FAILED" -eq 0 ] || return 1
+  return 0
+}
+
+cmd_shell() {
+  doctor >/dev/null
+  local profile="${SELECTED:-ubuntu}"
+  build_artifacts
+  start_registry
+  trap 'stop_registry' EXIT
+  build_image "${TARGET_IMAGE_PREFIX}-${profile}" "Containerfile.${profile}"
+
+  local base="http://host.containers.internal:${REGISTRY_PORT}"
+  podman run --rm -it --user sandbox \
+    -e HOME=/home/sandbox \
+    -e SANDBOX_SCRIPTS=/scripts \
+    -e SANDBOX_PROFILE="$profile" \
+    -e DEADROP_RELEASES_API="$base/releases" \
+    -e DEADROP_RELEASES_DOWNLOAD_BASE="$base/download" \
+    -v "$REPO_ROOT/cli:/scripts:ro" \
+    -v "$SANDBOX_DIR/lib:/sandbox/lib:ro" \
+    -v "$SANDBOX_DIR/scenarios:/sandbox/scenarios:ro" \
+    "${TARGET_IMAGE_PREFIX}-${profile}" bash
+}
+
+COMMAND="${1:-}"
+[ $# -gt 0 ] && shift
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --profile) SELECTED="$2"; PROFILES=("$2"); shift 2 ;;
+    --scenario) FILTER="$2"; shift 2 ;;
+    --verbose) VERBOSE=1; shift ;;
+    *) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+case "$COMMAND" in
+  doctor) doctor ;;
+  list) cmd_list ;;
+  run) cmd_run ;;
+  shell) cmd_shell ;;
+  ''|-h|--help|help) usage ;;
+  *) printf 'unknown command: %s\n\n' "$COMMAND" >&2; usage; exit 2 ;;
+esac

--- a/tests/sandbox/scenarios/10-install-cli.sh
+++ b/tests/sandbox/scenarios/10-install-cli.sh
@@ -8,9 +8,12 @@ scenario "10-install-cli"
 
 assert_registry_reachable
 
-# No TTY here, which is the point — install.sh must not block on its PATH
-# prompt in a pipe, a Dockerfile, or CI.
-run_ok bash "$SANDBOX_SCRIPTS/install.sh"
+# `sh`, not `bash`: the documented install is `curl ... | sh`, and /bin/sh is
+# dash on Debian/Ubuntu. Running this under bash hid a `set -o pipefail` that
+# killed the real install on line 2.
+# No TTY here either, which is the point — install.sh must not block on its
+# PATH prompt in a pipe, a Dockerfile, or CI.
+run_ok sh "$SANDBOX_SCRIPTS/install.sh"
 INSTALL_OUT="$LAST_STDOUT$LAST_STDERR"
 
 assert_contains "$INSTALL_OUT" "Checksum verified"
@@ -36,7 +39,7 @@ fi
 rm -f "$BIN"
 run_fails env \
   DEADROP_RELEASES_DOWNLOAD_BASE="${DEADROP_RELEASES_DOWNLOAD_BASE%/download}/tampered" \
-  bash "$SANDBOX_SCRIPTS/install.sh"
+  sh "$SANDBOX_SCRIPTS/install.sh"
 assert_contains "$LAST_STDERR" "Checksum verification failed"
 
 if [ -f "$BIN" ]; then

--- a/tests/sandbox/scenarios/10-install-cli.sh
+++ b/tests/sandbox/scenarios/10-install-cli.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# install.sh, run the way a user runs it: on a machine with no toolchain,
+# against an artifact built somewhere else.
+
+. "$(dirname "$0")/../lib/harness.sh"
+
+scenario "10-install-cli"
+
+assert_registry_reachable
+
+# No TTY here, which is the point — install.sh must not block on its PATH
+# prompt in a pipe, a Dockerfile, or CI.
+run_ok bash "$SANDBOX_SCRIPTS/install.sh"
+INSTALL_OUT="$LAST_STDOUT$LAST_STDERR"
+
+assert_contains "$INSTALL_OUT" "Checksum verified"
+# ~/.local/bin is not on PATH in a bare container, so the manual instruction
+# has to appear rather than the script silently succeeding.
+assert_contains "$INSTALL_OUT" "is not in your PATH"
+
+BIN="$HOME/.local/bin/deadrop"
+assert_file_exists "$BIN"
+assert_executable "$BIN"
+
+# The assertion that matters: placement and mode bits prove nothing if the
+# binary can't run on this distro.
+run_ok "$BIN" --version
+if printf '%s' "$LAST_STDOUT" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+  pass "--version printed a semver ($LAST_STDOUT)"
+else
+  fail "--version printed '$LAST_STDOUT', expected a semver"
+fi
+
+# A payload that doesn't match its checksum must abort, and must not leave a
+# binary behind. The registry serves a corrupted copy under /tampered.
+rm -f "$BIN"
+run_fails env \
+  DEADROP_RELEASES_DOWNLOAD_BASE="${DEADROP_RELEASES_DOWNLOAD_BASE%/download}/tampered" \
+  bash "$SANDBOX_SCRIPTS/install.sh"
+assert_contains "$LAST_STDERR" "Checksum verification failed"
+
+if [ -f "$BIN" ]; then
+  fail "install proceeded despite a checksum mismatch"
+else
+  pass "no binary installed after checksum failure"
+fi
+
+finish

--- a/tests/sandbox/scenarios/10-install-cli.sh
+++ b/tests/sandbox/scenarios/10-install-cli.sh
@@ -8,12 +8,14 @@ scenario "10-install-cli"
 
 assert_registry_reachable
 
+INSTALL_SH=$(install_script install.sh)
+
 # `sh`, not `bash`: the documented install is `curl ... | sh`, and /bin/sh is
 # dash on Debian/Ubuntu. Running this under bash hid a `set -o pipefail` that
 # killed the real install on line 2.
 # No TTY here either, which is the point — install.sh must not block on its
 # PATH prompt in a pipe, a Dockerfile, or CI.
-run_ok sh "$SANDBOX_SCRIPTS/install.sh"
+run_ok sh "$INSTALL_SH"
 INSTALL_OUT="$LAST_STDOUT$LAST_STDERR"
 
 assert_contains "$INSTALL_OUT" "Checksum verified"
@@ -35,17 +37,22 @@ else
 fi
 
 # A payload that doesn't match its checksum must abort, and must not leave a
-# binary behind. The registry serves a corrupted copy under /tampered.
-rm -f "$BIN"
-run_fails env \
-  DEADROP_RELEASES_DOWNLOAD_BASE="${DEADROP_RELEASES_DOWNLOAD_BASE%/download}/tampered" \
-  sh "$SANDBOX_SCRIPTS/install.sh"
-assert_contains "$LAST_STDERR" "Checksum verification failed"
-
-if [ -f "$BIN" ]; then
-  fail "install proceeded despite a checksum mismatch"
+# binary behind. The registry serves a corrupted copy under /tampered; there is
+# no equivalent against live GitHub, so released mode can't cover this.
+if released_mode; then
+  skip "tamper test needs the local registry"
 else
-  pass "no binary installed after checksum failure"
+  rm -f "$BIN"
+  run_fails env \
+    DEADROP_RELEASES_DOWNLOAD_BASE="${DEADROP_RELEASES_DOWNLOAD_BASE%/download}/tampered" \
+    sh "$INSTALL_SH"
+  assert_contains "$LAST_STDERR" "Checksum verification failed"
+
+  if [ -f "$BIN" ]; then
+    fail "install proceeded despite a checksum mismatch"
+  else
+    pass "no binary installed after checksum failure"
+  fi
 fi
 
 finish

--- a/web/pages/docs/features/cli.mdx
+++ b/web/pages/docs/features/cli.mdx
@@ -255,7 +255,7 @@ deadrop inject -v prod -- pnpm build
 
 ### `desktop install`
 
-Install (or update, if already installed) the [desktop app](/docs/features/desktop). Works on macOS, Windows, and Linux — silent install on all three (macOS via `.dmg`, Windows via a silent NSIS install, Linux via an AppImage placed in `~/.local/bin`).
+Install (or update, if already installed) the [desktop app](/docs/features/desktop). Works on macOS, Windows, and Linux, installing silently on all three (macOS via `.dmg`, Windows via a silent NSIS install, Linux via an AppImage placed in `~/.local/bin`).
 
 ```
 deadrop desktop install
@@ -263,6 +263,16 @@ deadrop desktop install --force   # reinstall even if already on the latest vers
 ```
 
 `deadrop update` also offers to update desktop automatically if it's already installed (pass `--skip-desktop` to opt out).
+
+### `desktop uninstall`
+
+Remove the desktop app. On Linux this also removes the `.desktop` entry and the icon that the install registered, so no dead launcher is left behind in the application menu. On macOS it removes `/Applications/deadrop.app`. On Windows it points you at Settings > Apps, since the NSIS installer owns its own uninstaller.
+
+```
+deadrop desktop uninstall
+```
+
+This manages the AppImage install only. If you installed a `.deb` or `.rpm`, remove it with your package manager instead.
 
 ### `secret`
 

--- a/web/pages/docs/features/desktop.mdx
+++ b/web/pages/docs/features/desktop.mdx
@@ -3,8 +3,8 @@ import { DocsSectionTitle } from 'molecules/sections/SectionTitle';
 # 🖥️ Desktop App
 
 > **Experimental, macOS/Windows/Linux.** `deadrop desktop install` installs silently on all
-> three; `install-desktop.sh` covers macOS/Linux only (no native Windows shell support yet —
-> use the CLI there, or grab the build directly from
+> three; `install-desktop.sh` covers macOS/Linux only (no native Windows shell support yet,
+> so use the CLI there, or grab the build directly from
 > [GitHub Releases](https://github.com/dallen4/deadrop/releases)). The app is unsigned on
 > every platform, so expect an "unidentified developer"/SmartScreen warning on first launch.
 
@@ -37,6 +37,45 @@ curl -fsSL https://deadrop.io/install-desktop.sh | sh
 `deadrop update` also offers to update desktop automatically if it's already installed. See
 the [CLI docs](/docs/features/cli#commands) for flags.
 
+To remove it again:
+
+```
+deadrop desktop uninstall
+```
+
+or, if you installed with the script and don't have the CLI:
+
+```
+curl -fsSL https://deadrop.io/install-desktop.sh | sh -s -- --uninstall
+```
+
+<DocsSectionTitle
+  id={'linux-packages'}
+  label={'🐧 Linux packages (.deb / .rpm)'}
+/>
+
+The script and the CLI both install an AppImage, which runs on any distribution and needs no
+root. Every release also publishes native packages, which you may prefer if you'd rather your
+package manager own the install, the menu entry, and the updates. These are x86_64 only for
+now, so on ARM machines use the AppImage.
+
+Download the package for your release from
+[GitHub Releases](https://github.com/dallen4/deadrop/releases), then:
+
+```
+# Debian, Ubuntu, and derivatives
+sudo apt install ./deadrop_<version>_amd64.deb
+
+# Fedora, RHEL, and derivatives
+sudo dnf install ./deadrop-<version>-1.x86_64.rpm
+```
+
+Both register the application menu entry and icon for you, so there's no `.desktop` file to
+write by hand. Uninstall through the package manager as usual, with `sudo apt remove deadrop`
+or `sudo dnf remove deadrop`. Note that `deadrop desktop install` and `deadrop update` manage
+the AppImage only, so a package-manager install should be updated the same way it was
+installed.
+
 <DocsSectionTitle
   id={'dropping-and-grabbing'}
   label={'Dropping and grabbing'}
@@ -53,7 +92,7 @@ transfer runs the same peer-to-peer path as the browser, not the CLI's Node.js W
 
 The Vault tab prompts you to create a vault the first time you visit it, rather than
 creating one silently. It's stored on-device, and shares a default vault with the CLI
-automatically — no setup needed. Signed-in users with cloud access can enable Turso-backed
+automatically, with no setup needed. Signed-in users with cloud access can enable Turso-backed
 cloud sync for a vault from the same view, so its secrets stay available across devices. You
 can also link an existing project-scoped vault created by the CLI or the VS Code extension
 into the desktop app via "Import vault" in the vault switcher.


### PR DESCRIPTION
## Summary

We build and distribute for Linux but never actually *set it up*, so Linux bugs survive release. This branch adds a local container sandbox that installs deadrop the way an end user would, and fixes what it found.

**1. Linux install sandbox** (`tests/sandbox/`, spec in `specs/linux-sandbox-design.md`) — rootless Podman, `ubuntu` and `fedora` profiles, builder container + bare target container so the target starts with nothing installed. Success criterion is "installed means runnable", not "the build produced a file". Two modes:
- **local** serves the working tree through a stub release registry, so unreleased changes are testable
- **released** (`--released`) curls the published `deadrop.io/install.sh` and hits real GitHub releases, which is the only way to catch a script that is fine in-repo but broken as served

**2. The bug it found immediately.** `curl -fsSL https://deadrop.io/install.sh | sh` — the exact command on our homepage hero — died on line 2 of both install scripts with `set: Illegal option -o pipefail` and installed nothing on Debian/Ubuntu. `/bin/sh` is dash there and bash on macOS/Fedora, so this was invisible from a Mac and passed Fedora. Both scripts are now POSIX sh (`set -eu`, `command -v`, `case` instead of `[[ =~ ]]`). Scenario 10 previously ran `bash install.sh`, which is exactly what hid it; it now runs `sh`.

**3. Desktop uninstall** — installing on Linux writes to three places (AppImage, `.desktop` entry, hicolor icon) and nothing removed any of them, so deleting the AppImage by hand left a dead launcher in the application menu. Adds `deadrop desktop uninstall` and an `--uninstall` flag on `install-desktop.sh` (the flag exists because `curl | sh` doesn't get you the CLI, which would have left those users with no way to undo it). Icons are swept across every size bucket, since install picks its bucket from the extracted PNG's own dimensions.

**4. Desktop version drift** — `changeset version` only bumps `package.json`, but Tauri names bundles from `tauri.conf.json`, so `deadrop-desktop@0.2.2` shipped a full set of assets named `0.1.0`. `pnpm -F desktop sync-version` now writes `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock`, chained onto `changeset:version` so all four move together in the version PR, with a `--check` drift guard in Desktop CI. Also replaces the leftover `description = "A Tauri App"` / `authors = ["you"]` scaffold metadata.

**5. Assorted Linux setup fixes** found along the way — arch-specific AppImage selection (an x64 user could be handed an aarch64 binary), `deadrop init` running unattended, all package managers listed in the keychain remediation hint, and checksums published for every desktop bundle rather than just the ones our own installers consume.

Docs updated for uninstall and for `.deb`/`.rpm` installs, which we publish but never documented.

Changesets: `cli` minor (desktop uninstall), `cli` patch (POSIX install scripts), `desktop` patch (version sync), plus the two already on the branch.

## Test plan
- [x] Full unit suite: 230 tests / 40 files passing
- [x] Real `curl … | sh` install verified end-to-end in the sandbox on both ubuntu and fedora — installs `deadrop@1.7.0` and the binary runs
- [x] Reproduced the pipefail failure on bare `ubuntu:24.04` before the fix (`exit=2`, `set: Illegal option -o pipefail`) and confirmed it gone after
- [x] `cargo metadata` parses the manifest and reports `deadrop@0.2.2`, MIT, real description
- [x] `sync-version --check` exits 1 on drifted state listing all three files, 0 after syncing; diff is one line per file with no reformatting
- [x] Typecheck error count unchanged vs. `main` (4, all pre-existing)
- [ ] **`--released` mode is expected to fail on ubuntu until this merges** — `deadrop.io/install.sh` rewrites to the `main` branch, so it serves the broken script until then. Local mode passes both profiles.
- [ ] Desktop AppImage install (scenario 20) not yet covered — blocked on an aarch64 desktop build; we only publish x86_64, which can't exec under qemu
- [ ] Scenarios 20-70 (desktop install, config paths, keychain degradation, glibc floor, desktop integration, first run) still to be written
