### PR TITLE
feat(cli): add vault list command and select UI for vault use

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -50,7 +50,8 @@ deadrop drop            # Share a secret (drives dropMachine)
 deadrop grab            # Receive a secret (drives grabMachine)
 deadrop inject           # Run a command with vault secrets injected as env vars
 deadrop vault create    # Create a local vault (seeds development + production envs)
-deadrop vault use       # Switch active vault (--environment to also switch env)
+deadrop vault list      # List all vaults in the config
+deadrop vault use       # Switch active vault (--environment to also switch env; prompts to select when name omitted)
 deadrop vault sync      # Sync vault ↔ .env file
 deadrop vault export
 deadrop vault import

--- a/cli/actions/vault/index.ts
+++ b/cli/actions/vault/index.ts
@@ -3,5 +3,6 @@ export * from './delete';
 export * from './env';
 export * from './export';
 export * from './import';
+export * from './list';
 export * from './sync';
 export * from './use';

--- a/cli/actions/vault/list.ts
+++ b/cli/actions/vault/list.ts
@@ -1,0 +1,29 @@
+import chalk from 'chalk';
+import { loadConfig } from 'lib/config';
+import { logInfo } from 'lib/log';
+import { exit } from 'process';
+
+export async function vaultList() {
+  const { config } = await loadConfig();
+
+  const { vaults, active_vault } = config;
+
+  const vaultNames = Object.keys(vaults);
+
+  if (!vaultNames.length) {
+    logInfo('No vaults configured yet, run `deadrop vault create` to get started.');
+    return exit(0);
+  }
+
+  vaultNames.forEach((name) => {
+    const { location, cloud } = vaults[name];
+    const isActive = name === active_vault.name;
+    const marker = isActive ? chalk.green('*') : ' ';
+    const label = isActive ? chalk.bold(name) : name;
+    const cloudTag = cloud ? chalk.cyan(' [cloud]') : '';
+
+    logInfo(`${marker} ${label}${cloudTag} — ${location}`);
+  });
+
+  return exit(0);
+}

--- a/cli/actions/vault/use.ts
+++ b/cli/actions/vault/use.ts
@@ -1,3 +1,4 @@
+import { select } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { vaultExists } from 'db/vaults';
 import { loadConfig, saveConfig } from 'lib/config';
@@ -7,7 +8,7 @@ import { exit } from 'process';
 import { DeadropConfig } from '@shared/types/config';
 
 export async function vaultUse(
-  vaultNameInput: string,
+  vaultNameInput: string | undefined,
   options: { environment?: string } = {},
 ) {
   const { config, filepath: configPath } = await loadConfig();
@@ -15,8 +16,22 @@ export async function vaultUse(
   const { vaults, active_vault } = config;
 
   if (!vaultNameInput) {
-    logError('Vault name is required to delete!');
-    return exit(1);
+    const vaultNames = Object.keys(vaults);
+
+    if (!vaultNames.length) {
+      logError('No vaults configured, run `deadrop vault create` first!');
+      return exit(1);
+    }
+
+    vaultNameInput = await select({
+      message: 'Select a vault to switch to',
+      choices: vaultNames.map((name) => ({
+        name:
+          name === active_vault.name ? `${name} (active)` : name,
+        value: name,
+      })),
+      default: active_vault.name,
+    });
   }
 
   if (!vaultExists(vaults, vaultNameInput)) {

--- a/cli/core.ts
+++ b/cli/core.ts
@@ -14,6 +14,7 @@ import {
   vaultEnvList,
   vaultExport,
   vaultImport,
+  vaultList,
   vaultSync,
   vaultUse,
 } from 'actions/vault';
@@ -141,9 +142,17 @@ add cloud-based replica for ease of sharing`,
   .action(vaultCreate);
 
 vaultRoot
+  .command('list')
+  .description('list all vaults available in the config')
+  .action(vaultList);
+
+vaultRoot
   .command('use')
   .description('change the current active vault deadrop is using')
-  .argument('<name>', 'name of the vault to switch to as active')
+  .argument(
+    '[name]',
+    'name of the vault to switch to as active (prompts to select when omitted)',
+  )
   .option('-e, --environment <env>', 'environment to switch to')
   .action(vaultUse);
 

--- a/cli/tests/unit/vault-list.spec.ts
+++ b/cli/tests/unit/vault-list.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('lib/config', () => ({
+  loadConfig: vi.fn(),
+}));
+
+vi.mock('lib/log', () => ({
+  logInfo: vi.fn(),
+}));
+
+vi.mock('process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('process')>();
+  return { ...actual, exit: vi.fn() };
+});
+
+describe('vaultList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs each vault and marks the active one', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { logInfo } = await import('lib/log');
+    const { vaultList } = await import('actions/vault/list');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'production' },
+        vaults: {
+          default: { location: '/tmp/default.db', environments: {} },
+          other: { location: '/tmp/other.db', environments: {} },
+        },
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+
+    await vaultList();
+
+    expect(logInfo).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(logInfo).mock.calls[0][0]).toContain('default');
+    expect(vi.mocked(logInfo).mock.calls[1][0]).toContain('other');
+  });
+
+  it('logs a helpful message when there are no vaults', async () => {
+    const { loadConfig } = await import('lib/config');
+    const { logInfo } = await import('lib/log');
+    const { vaultList } = await import('actions/vault/list');
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: '', environment: '' },
+        vaults: {},
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+
+    await vaultList();
+
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logInfo).mock.calls[0][0]).toContain(
+      'deadrop vault create',
+    );
+  });
+});

--- a/cli/tests/unit/vault-use.spec.ts
+++ b/cli/tests/unit/vault-use.spec.ts
@@ -14,6 +14,10 @@ vi.mock('db/vaults', () => ({
   vaultExists: vi.fn(),
 }));
 
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+}));
+
 vi.mock('process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('process')>();
   return { ...actual, exit: vi.fn() };
@@ -108,6 +112,39 @@ describe('vaultUse', () => {
       expect.anything(),
       expect.objectContaining({
         active_vault: { name: 'default', environment: 'production' },
+      }),
+      true,
+    );
+  });
+
+  it('prompts to select a vault when no name is passed', async () => {
+    const { loadConfig, saveConfig } = await import('lib/config');
+    const { vaultExists } = await import('db/vaults');
+    const { select } = await import('@inquirer/prompts');
+    const { vaultUse } = await import('actions/vault/use');
+
+    const vaults = {
+      default: { location: '/tmp/default.db', environments: {} },
+      other: { location: '/tmp/other.db', environments: {} },
+    };
+
+    vi.mocked(loadConfig).mockResolvedValue({
+      config: {
+        active_vault: { name: 'default', environment: 'production' },
+        vaults,
+      },
+      filepath: '/tmp/.deadroprc',
+    } as any);
+    vi.mocked(vaultExists).mockReturnValue(vaults.other as any);
+    vi.mocked(select).mockResolvedValue('other');
+
+    await vaultUse(undefined as any);
+
+    expect(select).toHaveBeenCalled();
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        active_vault: { name: 'other', environment: 'production' },
       }),
       true,
     );


### PR DESCRIPTION
## Summary
- Add `deadrop vault list` to list all vaults in the config, marking the active vault and any cloud-backed ones
- `deadrop vault use` now accepts an optional vault name; when omitted it prompts with an interactive select UI (`@inquirer/prompts`) listing configured vaults, defaulting to the current active one

## Test plan
- [x] `pnpm -F cli exec vitest run tests/unit/vault-use.spec.ts tests/unit/vault-list.spec.ts`
- [x] `pnpm -F cli exec tsc --noEmit` (no new errors introduced; pre-existing unrelated errors in worker types / drizzle config remain)
- [x] Full `pnpm test` run (233 passed; 1 pre-existing unrelated failure in crypto.spec.ts due to a missing fixture symlink in the worktree)